### PR TITLE
[#11] feat: 기사 배차 선택 api 구현, 로그인 사용자 커스텀 어노테이션 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,9 @@ dependencies {
 	// Postgresql
 	runtimeOnly 'org.postgresql:postgresql'
 
+	// Spring Security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+
 	// Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/src/main/java/com/mobility/api/domain/dispatch/entity/Dispatch.java
+++ b/src/main/java/com/mobility/api/domain/dispatch/entity/Dispatch.java
@@ -3,6 +3,8 @@ package com.mobility.api.domain.dispatch.entity;
 import com.mobility.api.domain.dispatch.enums.CallType;
 import com.mobility.api.domain.dispatch.enums.ServiceType;
 import com.mobility.api.domain.dispatch.enums.StatusType;
+import com.mobility.api.domain.transporter.entity.Transporter;
+import com.mobility.api.global.exception.GlobalExceptionHandler;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.Comment;
@@ -40,8 +42,23 @@ public class Dispatch {
     // FIXME office_id : 사무실 id :: 외래키 설정 필요
     private Long officeId;
 
-    // TODO transporter_id : 기사 id
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "transporter_id")
+    private Transporter transporter;
 
     private LocalDateTime createdAt; // 생성일자
+
+    // 기사 배차 시
+    public void assignDispatch(Transporter transporter) {
+        // 1. 유효성 검증 : 이미 배차되어있는지 확인
+        if (this.status != StatusType.OPEN) {
+            // todo: GlobalException 예외처리 - 배차 불가능합니다. (OPEN 상태 아님)
+            System.out.println("Status is not open");
+        }
+
+         // 2. 상태 변경
+        this.transporter = transporter;
+        this.status = StatusType.ASSIGNED;
+    }
 
 }

--- a/src/main/java/com/mobility/api/domain/dispatch/entity/Dispatch.java
+++ b/src/main/java/com/mobility/api/domain/dispatch/entity/Dispatch.java
@@ -4,7 +4,9 @@ import com.mobility.api.domain.dispatch.enums.CallType;
 import com.mobility.api.domain.dispatch.enums.ServiceType;
 import com.mobility.api.domain.dispatch.enums.StatusType;
 import com.mobility.api.domain.transporter.entity.Transporter;
+import com.mobility.api.global.exception.GlobalException;
 import com.mobility.api.global.exception.GlobalExceptionHandler;
+import com.mobility.api.global.response.ResultCode;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.Comment;
@@ -50,13 +52,12 @@ public class Dispatch {
 
     // 기사 배차 시
     public void assignDispatch(Transporter transporter) {
+
         // 1. 유효성 검증 : 이미 배차되어있는지 확인
         if (this.status != StatusType.OPEN) {
-            // todo: GlobalException 예외처리 - 배차 불가능합니다. (OPEN 상태 아님)
-            System.out.println("Status is not open");
+            throw new GlobalException(ResultCode.FORBIDDEN);
         }
 
-         // 2. 상태 변경
         this.transporter = transporter;
         this.status = StatusType.ASSIGNED;
     }

--- a/src/main/java/com/mobility/api/domain/dispatch/repository/DispatchRepository.java
+++ b/src/main/java/com/mobility/api/domain/dispatch/repository/DispatchRepository.java
@@ -1,7 +1,18 @@
 package com.mobility.api.domain.dispatch.repository;
 
 import com.mobility.api.domain.dispatch.entity.Dispatch;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface DispatchRepository extends JpaRepository<Dispatch, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT d FROM Dispatch d WHERE d.id = :dispatchId")
+    Optional<Dispatch> findByIdWithPessimisticLock(@Param("dispatchId") Long dispatchId);
+
 }

--- a/src/main/java/com/mobility/api/domain/dispatch/service/DispatcherService.java
+++ b/src/main/java/com/mobility/api/domain/dispatch/service/DispatcherService.java
@@ -1,0 +1,38 @@
+package com.mobility.api.domain.dispatch.service;
+
+import com.mobility.api.domain.dispatch.entity.Dispatch;
+import com.mobility.api.domain.dispatch.repository.DispatchRepository;
+import com.mobility.api.domain.transporter.dto.request.DispatchAssignReq;
+import com.mobility.api.domain.transporter.dto.response.DispatchAssignRes;
+import com.mobility.api.domain.transporter.entity.Transporter;
+import com.mobility.api.domain.transporter.repository.TransporterRepository;
+import com.mobility.api.global.exception.GlobalException;
+import com.mobility.api.global.response.ResultCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DispatcherService {
+
+    private final DispatchRepository dispatchRepository;
+    private final TransporterRepository transporterRepository;
+
+    // 기사가 배차를 선택
+    public DispatchAssignRes assignDispatch(Long dispatchId, Long transporterId) {
+
+        // 1. 기사 정보 조회
+        Transporter transporter = transporterRepository.findById(transporterId)
+                .orElseThrow(() -> new GlobalException(ResultCode.NOT_FOUND_USER));
+
+        // 2. 배차 정보 조회 -> DB 로우에 락이 걸림
+        Dispatch dispatch = dispatchRepository.findByIdWithPessimisticLock(dispatchId)
+                .orElseThrow(() -> new GlobalException(ResultCode.NOT_FOUND_DISPATCH));
+
+        // 3. 배차 할당
+        dispatch.assignDispatch(transporter);
+
+        return DispatchAssignRes.from(dispatch);
+    }
+
+}

--- a/src/main/java/com/mobility/api/domain/dispatch/service/DispatcherService.java
+++ b/src/main/java/com/mobility/api/domain/dispatch/service/DispatcherService.java
@@ -2,12 +2,12 @@ package com.mobility.api.domain.dispatch.service;
 
 import com.mobility.api.domain.dispatch.entity.Dispatch;
 import com.mobility.api.domain.dispatch.repository.DispatchRepository;
-import com.mobility.api.domain.transporter.dto.request.DispatchAssignReq;
 import com.mobility.api.domain.transporter.dto.response.DispatchAssignRes;
 import com.mobility.api.domain.transporter.entity.Transporter;
 import com.mobility.api.domain.transporter.repository.TransporterRepository;
 import com.mobility.api.global.exception.GlobalException;
 import com.mobility.api.global.response.ResultCode;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -19,6 +19,7 @@ public class DispatcherService {
     private final TransporterRepository transporterRepository;
 
     // 기사가 배차를 선택
+    @Transactional
     public DispatchAssignRes assignDispatch(Long dispatchId, Long transporterId) {
 
         // 1. 기사 정보 조회
@@ -34,5 +35,4 @@ public class DispatcherService {
 
         return DispatchAssignRes.from(dispatch);
     }
-
 }

--- a/src/main/java/com/mobility/api/domain/transporter/controller/TransporterController.java
+++ b/src/main/java/com/mobility/api/domain/transporter/controller/TransporterController.java
@@ -1,10 +1,15 @@
 package com.mobility.api.domain.transporter.controller;
 
 import com.mobility.api.domain.dispatch.service.DispatcherService;
+import com.mobility.api.domain.transporter.entity.Transporter;
 import com.mobility.api.domain.transporter.service.TransporterService;
+import com.mobility.api.global.annotation.CurrentUser;
+import com.mobility.api.global.exception.GlobalException;
 import com.mobility.api.global.response.CommonResponse;
 import com.mobility.api.global.response.ResultCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -12,20 +17,24 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api1/v1/transporter")
 public class TransporterController {
 
-    private final TransporterService transporterService;
     private final DispatcherService dispatcherService;
 
     @PatchMapping("/dispatch-assign/{dispatch_id}")
-    public CommonResponse<ResultCode> assignDispatch(@PathVariable Long dispatch_id, @AuthenticationPrincipal UserDetails userDetails) { // // todo spring security 로그인한 사용자 정보 가져오기
+    public CommonResponse<ResultCode> assignDispatch(@PathVariable Long dispatch_id, @CurrentUser Transporter transporter) { 
 
-        Long transporterId = userDetails.getTransporterId();
+        Long transporterId = transporter.getId();
+
+        if  (transporterId == null) {
+            throw new GlobalException(ResultCode.NOT_FOUND_USER);
+        }
+
         dispatcherService.assignDispatch(dispatch_id, transporterId);
 
         return CommonResponse.success(ResultCode.DISPATCH_ASSIGN_SUCCESS);
     }
 
-    @PatchMapping("dispatch-cancel/{dispatchId}")
+//    @PatchMapping("dispatch-cancel/{dispatchId}")
 
-    @PatchMapping("/dispatch-complete/{dispatchId}")
+//    @PatchMapping("/dispatch-complete/{dispatchId}")
 
 }

--- a/src/main/java/com/mobility/api/domain/transporter/controller/TransporterController.java
+++ b/src/main/java/com/mobility/api/domain/transporter/controller/TransporterController.java
@@ -2,14 +2,11 @@ package com.mobility.api.domain.transporter.controller;
 
 import com.mobility.api.domain.dispatch.service.DispatcherService;
 import com.mobility.api.domain.transporter.entity.Transporter;
-import com.mobility.api.domain.transporter.service.TransporterService;
 import com.mobility.api.global.annotation.CurrentUser;
 import com.mobility.api.global.exception.GlobalException;
 import com.mobility.api.global.response.CommonResponse;
 import com.mobility.api.global.response.ResultCode;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -20,7 +17,7 @@ public class TransporterController {
     private final DispatcherService dispatcherService;
 
     @PatchMapping("/dispatch-assign/{dispatch_id}")
-    public CommonResponse<ResultCode> assignDispatch(@PathVariable Long dispatch_id, @CurrentUser Transporter transporter) { 
+    public CommonResponse<ResultCode> assignDispatch(@PathVariable Long dispatch_id, @CurrentUser Transporter transporter) {
 
         Long transporterId = transporter.getId();
 

--- a/src/main/java/com/mobility/api/domain/transporter/controller/TransporterController.java
+++ b/src/main/java/com/mobility/api/domain/transporter/controller/TransporterController.java
@@ -1,0 +1,31 @@
+package com.mobility.api.domain.transporter.controller;
+
+import com.mobility.api.domain.dispatch.service.DispatcherService;
+import com.mobility.api.domain.transporter.service.TransporterService;
+import com.mobility.api.global.response.CommonResponse;
+import com.mobility.api.global.response.ResultCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api1/v1/transporter")
+public class TransporterController {
+
+    private final TransporterService transporterService;
+    private final DispatcherService dispatcherService;
+
+    @PatchMapping("/dispatch-assign/{dispatch_id}")
+    public CommonResponse<ResultCode> assignDispatch(@PathVariable Long dispatch_id, @AuthenticationPrincipal UserDetails userDetails) { // // todo spring security 로그인한 사용자 정보 가져오기
+
+        Long transporterId = userDetails.getTransporterId();
+        dispatcherService.assignDispatch(dispatch_id, transporterId);
+
+        return CommonResponse.success(ResultCode.DISPATCH_ASSIGN_SUCCESS);
+    }
+
+    @PatchMapping("dispatch-cancel/{dispatchId}")
+
+    @PatchMapping("/dispatch-complete/{dispatchId}")
+
+}

--- a/src/main/java/com/mobility/api/domain/transporter/dto/response/DispatchAssignRes.java
+++ b/src/main/java/com/mobility/api/domain/transporter/dto/response/DispatchAssignRes.java
@@ -1,0 +1,21 @@
+package com.mobility.api.domain.transporter.dto.response;
+
+import com.mobility.api.domain.dispatch.entity.Dispatch;
+import com.mobility.api.global.exception.GlobalException;
+import com.mobility.api.global.response.ResultCode;
+
+public record DispatchAssignRes(
+        Long dispatcherId,
+        Long transporterId
+) {
+    public static DispatchAssignRes from(Dispatch dispatch) {
+        if (dispatch.getTransporter() != null) {
+            throw new GlobalException(ResultCode.NOT_FOUND_USER);
+        }
+
+        return new DispatchAssignRes(
+                dispatch.getId(),
+                dispatch.getTransporter().getId()
+        );
+    }
+}

--- a/src/main/java/com/mobility/api/domain/transporter/entity/Transporter.java
+++ b/src/main/java/com/mobility/api/domain/transporter/entity/Transporter.java
@@ -8,23 +8,26 @@ import org.hibernate.annotations.UpdateTimestamp;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "transporters")
 @Getter
 @Setter
 @NoArgsConstructor // @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
+@Table(name = "transporters")
 public class Transporter {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "transporter_id")
     private Long id;
 
-    @Column(length = 20)
+    @Column(name = "name", length = 20)
     private String name;
 
+    @Column(name = "phone")
     private String phone;
 
+    @Column(name = "is_auto_dispatch")
     private boolean isAutoDispatch;
 
     @CreationTimestamp

--- a/src/main/java/com/mobility/api/domain/transporter/entity/Transporter.java
+++ b/src/main/java/com/mobility/api/domain/transporter/entity/Transporter.java
@@ -1,4 +1,38 @@
 package com.mobility.api.domain.transporter.entity;
 
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "transporters")
+@Getter
+@Setter
+@NoArgsConstructor // @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 public class Transporter {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 20)
+    private String name;
+
+    private String phone;
+
+    private boolean isAutoDispatch;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "update_at")
+    private LocalDateTime updatedAt;
+
 }

--- a/src/main/java/com/mobility/api/domain/transporter/entity/Transporter.java
+++ b/src/main/java/com/mobility/api/domain/transporter/entity/Transporter.java
@@ -1,0 +1,4 @@
+package com.mobility.api.domain.transporter.entity;
+
+public class Transporter {
+}

--- a/src/main/java/com/mobility/api/domain/transporter/repository/TransporterRepository.java
+++ b/src/main/java/com/mobility/api/domain/transporter/repository/TransporterRepository.java
@@ -1,0 +1,7 @@
+package com.mobility.api.domain.transporter.repository;
+
+import com.mobility.api.domain.transporter.entity.Transporter;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TransporterRepository extends JpaRepository<Transporter, Long> {
+}

--- a/src/main/java/com/mobility/api/domain/transporter/service/TransporterService.java
+++ b/src/main/java/com/mobility/api/domain/transporter/service/TransporterService.java
@@ -1,0 +1,7 @@
+package com.mobility.api.domain.transporter.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class TransporterService {
+}

--- a/src/main/java/com/mobility/api/global/annotation/CurrentUser.java
+++ b/src/main/java/com/mobility/api/global/annotation/CurrentUser.java
@@ -1,0 +1,8 @@
+package com.mobility.api.global.annotation;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface CurrentUser {}

--- a/src/main/java/com/mobility/api/global/config/CurrentUserArgumentResolver.java
+++ b/src/main/java/com/mobility/api/global/config/CurrentUserArgumentResolver.java
@@ -1,0 +1,68 @@
+package com.mobility.api.global.config;
+
+import com.mobility.api.domain.transporter.entity.Transporter;
+import com.mobility.api.global.annotation.CurrentUser;
+import com.mobility.api.global.security.PrincipalDetails;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    /**
+     * 이 Resolver가 어떤 파라미터를 지원(support)할 것인지 결정합
+     * @CurrentUser 어노테이션이 붙어있는 파라미터라면 true를 반환
+     */
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(CurrentUser.class);
+    }
+
+    /**
+     * supportsParameter가 true를 반환했을 때,
+     * 파라미터에 실제로 주입할 값(Object)을 결정(resolve)하여 반환합니다.
+     */
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        // 1. 인증 정보가 없거나, principal이 PrincipalDetails 타입이 아닌 경우 (예: 익명 사용자)
+        if (authentication == null || !(authentication.getPrincipal() instanceof PrincipalDetails)) {
+            // 5. 혹은 인증이 필수인 경우 여기서 예외(Exception)를 던져도 됩니다.
+            return null;
+        }
+
+        PrincipalDetails principalDetails = (PrincipalDetails) authentication.getPrincipal();
+
+        // 2. 컨트롤러가 요청한 파라미터의 타입을 확인합니다.
+        Class<?> parameterType = parameter.getParameterType();
+
+        // 3. 타입에 따라 원하는 값을 반환합니다.
+        if (Long.class.isAssignableFrom(parameterType)) {
+            // @CurrentUser Long transporterId
+            return principalDetails.getTransporterId();
+        }
+
+//        if (Transporter.class.isAssignableFrom(parameterType)) {
+//            // @CurrentUser Transporter transporter
+//            // 6. PrincipalDetails에 getTransporter() 메서드가 있다고 가정
+//            return principalDetails.getTransporter();
+//        }
+
+        if (PrincipalDetails.class.isAssignableFrom(parameterType)) {
+            // @CurrentUser PrincipalDetails principalDetails
+            return principalDetails;
+        }
+
+        // 4. 지원하지 않는 타입이 요청된 경우
+        throw new IllegalArgumentException("지원하지 않는 파라미터 타입입니다: " + parameterType);
+    }
+}

--- a/src/main/java/com/mobility/api/global/config/WebConfig.java
+++ b/src/main/java/com/mobility/api/global/config/WebConfig.java
@@ -1,0 +1,20 @@
+package com.mobility.api.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final CurrentUserArgumentResolver currentUserArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(currentUserArgumentResolver);
+    }
+}

--- a/src/main/java/com/mobility/api/global/response/ResultCode.java
+++ b/src/main/java/com/mobility/api/global/response/ResultCode.java
@@ -12,9 +12,26 @@ public enum ResultCode {
      */
     SUCCESS(HttpStatus.OK, 0, "정상 처리 되었습니다."),
     INVALID_INPUT(HttpStatus.BAD_REQUEST, 1000, "잘못된 입력값입니다."),
-    NOT_FOUND_USER(HttpStatus.NOT_FOUND, 1003, "사용자를 찾을 수 없습니다."),
-    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, 1006, "인증이 필요합니다."),
-    FORBIDDEN(HttpStatus.FORBIDDEN, 1007, "권한이 없는 사용자입니다.");
+    NOT_FOUND_USER(HttpStatus.NOT_FOUND, 1001, "사용자를 찾을 수 없습니다."),
+    NOT_FOUND_DISPATCH(HttpStatus.NOT_FOUND, 1002, "배차 정보를 찾을 수 없습니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, 1003, "인증이 필요합니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, 1004, "권한이 없는 사용자입니다."),
+
+    /**
+     * 2000번대 (배차 관련)
+     */
+    DISPATCH_ASSIGN_SUCCESS(HttpStatus.OK, 2001, "배차가 상공적으로 되었습니다"),
+    DISPATCH_STATUS_IS_NOT_OPEN(HttpStatus.NOT_FOUND, 2002, "배차 상태가 OPEN이 아닙니다.");
+
+    /**
+     * 3000번대 (기사 관련)
+     */
+
+
+    /**
+     * 4000번대 (사무실 관련)
+     */
+
 
     private final HttpStatus status;
     private final int code;

--- a/src/main/java/com/mobility/api/global/security/PrincipalDetails.java
+++ b/src/main/java/com/mobility/api/global/security/PrincipalDetails.java
@@ -1,0 +1,42 @@
+package com.mobility.api.global.security;
+
+import com.mobility.api.domain.transporter.entity.Transporter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+public class PrincipalDetails implements UserDetails {
+
+    private final Transporter transporter; //  사용자 엔티티를 직접 보유
+
+    public PrincipalDetails(Transporter transporter) {
+        this.transporter = transporter;
+    }
+
+    // ArgumentResolver가 사용할 메서드
+//    public Transporter getTransporter() {
+//        return transporter;
+//    }
+
+    public Long getTransporterId() {
+//        return transporter.getId();
+        return null;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of();
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return "";
+    }
+}


### PR DESCRIPTION
## 관련 이슈
#11 

## 📌 작업 개요
- 기사 배차 선택 api 구현
- 로그인된 사용자 정보 찾기 spring security 구현

## ✨ 기타 참고 사항
- 기사가 배차를 선택하는 것이므로, transporter 도메인에 구현하였습니다.
- 배차 선택 시, 비관락을 이용하여 동시성 문제를 처리하였습니다.
- 로그인 되어있는 사용자 정보 호출관련 커스텀 어노테이션 구현했습니다. 확인 부탁드립니다.

## ✅ 체크리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] `application.yml` 파일을 수정했다면, Notion에 업로드, github security 수정 및 공유했어요.
- [x] 로컬 서버에서 정상 동작을 확인했어요. (main, test)
- [x] 불필요한 코드는 삭제했어요.