### PR TITLE
[#35] feat: 배차 등록 후 해당 배차 정보를 기반으로 반경 10km 내 기사 리스트 조회 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ dependencies {
 	// Postgresql
 	runtimeOnly 'org.postgresql:postgresql'
 
-//	 Postgis - Hibernate Spatial (JTS 타입을 DB Geometry 타입으로 매핑)
+	// Postgis - Hibernate Spatial (JTS 타입을 DB Geometry 타입으로 매핑)
     implementation 'org.hibernate.orm:hibernate-spatial'
 	implementation 'org.geolatte:geolatte-geom:1.8.2'
 
@@ -55,6 +55,7 @@ dependencies {
 
 	// Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.security:spring-security-test'
 
     // Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.14'

--- a/src/main/java/com/mobility/api/domain/dispatch/controller/DispatchV1Controller.java
+++ b/src/main/java/com/mobility/api/domain/dispatch/controller/DispatchV1Controller.java
@@ -13,7 +13,6 @@ import com.mobility.api.global.response.ResultCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;

--- a/src/main/java/com/mobility/api/domain/dispatch/controller/DispatchV1Controller.java
+++ b/src/main/java/com/mobility/api/domain/dispatch/controller/DispatchV1Controller.java
@@ -1,0 +1,47 @@
+package com.mobility.api.domain.dispatch.controller;
+
+// DispatchMatchingService 내부에서 TransporterService를 호출한다고 가정
+// 혹은 여기서 바로 TransporterService를 호출해도 무방
+
+import com.mobility.api.domain.transporter.dto.response.TransporterMatchResponse;
+import com.mobility.api.domain.transporter.service.TransporterService;
+import com.mobility.api.domain.dispatch.repository.DispatchRepository;
+import com.mobility.api.global.exception.GlobalException;
+import com.mobility.api.global.response.CommonResponse;
+import com.mobility.api.global.response.ResultCode;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "Dispatch Matching", description = "배차 매칭 관련 API")
+@RestController
+@RequestMapping("/api/v1/dispatch")
+@RequiredArgsConstructor
+public class DispatchV1Controller {
+
+    private final DispatchRepository dispatchRepository;
+    private final TransporterService transporterService;
+
+    // 배차 등록 시, 주변의 기사 조회 (km 단위 반환)
+    @Operation(summary = "배차 주변 기사 추천", description = "해당 배차의 출발지 기준 반경 50km 이내 기사를 가까운 순으로 조회합니다.")
+    @GetMapping("/{dispatchId}/nearby-drivers")
+    public CommonResponse<List<TransporterMatchResponse>> getNearbyDrivers(@PathVariable Long dispatchId) {
+
+        // 1. 배차 정보 조회 (출발지 좌표 획득)
+        var dispatch = dispatchRepository.findById(dispatchId)
+                .orElseThrow(() -> new GlobalException(ResultCode.DISPATCH_NOT_FOUND));
+
+        // 2. 기사 검색 서비스 호출
+        List<TransporterMatchResponse> drivers = transporterService.findNearbyTransporters(
+                dispatch.getStartLatitude(),
+                dispatch.getStartLongitude()
+        );
+
+        return CommonResponse.success(drivers);
+    }
+}

--- a/src/main/java/com/mobility/api/domain/dispatch/dto/request/DispatchReq.java
+++ b/src/main/java/com/mobility/api/domain/dispatch/dto/request/DispatchReq.java
@@ -1,0 +1,63 @@
+package com.mobility.api.domain.dispatch.dto.request;
+
+import com.mobility.api.domain.dispatch.entity.Dispatch;
+import com.mobility.api.domain.dispatch.enums.CallType;
+import com.mobility.api.domain.dispatch.enums.ServiceType;
+import com.mobility.api.domain.dispatch.enums.StatusType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+@Builder
+public record DispatchReq(
+        @NotBlank(message = "출발지는 필수입니다.")
+        String startLocation,
+
+        @NotNull(message = "출발지 위도는 필수입니다.")
+        Double startLatitude,
+
+        @NotNull(message = "출발지 경도는 필수입니다.")
+        Double startLongitude,
+
+        @NotBlank(message = "도착지는 필수입니다.")
+        String destinationLocation,
+
+        @NotNull(message = "도착지 위도는 필수입니다.")
+        Double destinationLatitude,
+
+        @NotNull(message = "도착지 경도는 필수입니다.")
+        Double destinationLongitude,
+
+        @NotNull(message = "요금은 필수입니다.")
+        Integer charge,
+
+        @NotBlank(message = "고객 전화번호는 필수입니다.")
+        String clientPhoneNumber,
+
+        @NotNull(message = "콜 타입은 필수입니다.")
+        CallType callType,
+
+        @NotNull(message = "서비스 타입은 필수입니다.")
+        ServiceType serviceType,
+
+        Long officeId
+) {
+    // DTO -> Entity 변환 메서드
+    public Dispatch toEntity() {
+        return Dispatch.builder()
+                .startLocation(startLocation)
+                .startLatitude(startLatitude)
+                .startLongitude(startLongitude)
+                .destinationLocation(destinationLocation)
+                .destinationLatitude(destinationLatitude)
+                .destinationLongitude(destinationLongitude)
+                .charge(charge)
+                .clientPhoneNumber(clientPhoneNumber)
+                .call(callType)
+                .service(serviceType)
+                .officeId(officeId)
+                .status(StatusType.OPEN) // 생성 시 기본 상태는 OPEN
+                .active(true)            // 생성 시 기본 활성화
+                .build();
+    }
+}

--- a/src/main/java/com/mobility/api/domain/dispatch/dto/response/DispatchAssignCompleteRes.java
+++ b/src/main/java/com/mobility/api/domain/dispatch/dto/response/DispatchAssignCompleteRes.java
@@ -1,0 +1,20 @@
+package com.mobility.api.domain.dispatch.dto.response;
+
+import com.mobility.api.domain.dispatch.entity.Dispatch;
+
+// 배차 선택, 완료 res
+public record DispatchAssignCompleteRes(
+        Long dispatcherId,
+        Long transporterId
+) {
+    public static DispatchAssignCompleteRes from(Dispatch dispatch) {
+//        if (dispatch.getTransporter() != null) {
+//            throw new GlobalException(ResultCode.NOT_FOUND_USER);
+//        }
+
+        return new DispatchAssignCompleteRes(
+                dispatch.getId(),
+                dispatch.getTransporter().getId()
+        );
+    }
+}

--- a/src/main/java/com/mobility/api/domain/dispatch/dto/response/DispatchRes.java
+++ b/src/main/java/com/mobility/api/domain/dispatch/dto/response/DispatchRes.java
@@ -1,20 +1,60 @@
 package com.mobility.api.domain.dispatch.dto.response;
 
 import com.mobility.api.domain.dispatch.entity.Dispatch;
+import com.mobility.api.domain.dispatch.enums.CallType;
+import com.mobility.api.domain.dispatch.enums.ServiceType;
+import com.mobility.api.domain.dispatch.enums.StatusType;
+import lombok.Builder;
 
-// 배차 선택, 완료 res
-public record DispatchRes(
-        Long dispatcherId,
-        Long transporterId
+import java.time.LocalDateTime;
+
+/**
+ * 배차 등록 res
+ */
+
+@Builder
+public record DispatchRes(Long id,
+                          String startLocation,
+                          Double startLatitude,
+                          Double startLongitude,
+                          String destinationLocation,
+                          Double destinationLatitude,
+                          Double destinationLongitude,
+                          Integer charge,
+                          String clientPhoneNumber,
+                          StatusType status,
+                          CallType callType,
+                          ServiceType serviceType,
+                          Long officeId,
+                          Long transporterId,      // 기사 ID (null 가능)
+                          String transporterName,  // 기사 이름 (null 가능)
+                          LocalDateTime createdAt
 ) {
+    // Entity -> DTO 변환 메서드 (거리는 별도 계산 없을 시 null)
     public static DispatchRes from(Dispatch dispatch) {
-//        if (dispatch.getTransporter() != null) {
-//            throw new GlobalException(ResultCode.NOT_FOUND_USER);
-//        }
+        return from(dispatch, null);
+    }
 
-        return new DispatchRes(
-                dispatch.getId(),
-                dispatch.getTransporter().getId()
-        );
+    // Entity + 거리 -> DTO 변환 메서드
+    public static DispatchRes from(Dispatch dispatch, Double distance) {
+        return DispatchRes.builder()
+                .id(dispatch.getId())
+                .startLocation(dispatch.getStartLocation())
+                .startLatitude(dispatch.getStartLatitude())
+                .startLongitude(dispatch.getStartLongitude())
+                .destinationLocation(dispatch.getDestinationLocation())
+                .destinationLatitude(dispatch.getDestinationLatitude())
+                .destinationLongitude(dispatch.getDestinationLongitude())
+                .charge(dispatch.getCharge())
+                .clientPhoneNumber(dispatch.getClientPhoneNumber())
+                .status(dispatch.getStatus())
+                .callType(dispatch.getCall())
+                .serviceType(dispatch.getService())
+                .officeId(dispatch.getOfficeId())
+                // Transporter가 lazy loading이거나 null일 수 있으므로 체크 필요
+                .transporterId(dispatch.getTransporter() != null ? dispatch.getTransporter().getId() : null)
+                .transporterName(dispatch.getTransporter() != null ? dispatch.getTransporter().getName() : null)
+                .createdAt(dispatch.getCreatedAt())
+                .build();
     }
 }

--- a/src/main/java/com/mobility/api/domain/dispatch/entity/Dispatch.java
+++ b/src/main/java/com/mobility/api/domain/dispatch/entity/Dispatch.java
@@ -26,7 +26,15 @@ public class Dispatch {
     private Long id;
 
     private String startLocation; // 출발지
+
+    private double startLatitude; // 출발지 위도
+    private double startLongitude; // 출발지 경도
+
     private String destinationLocation; // 도착지
+
+    private double destinationLatitude; // 도착지 위도
+    private double destinationLongitude; // 도착지 경도
+
     private Integer charge; // 요금
     private String clientPhoneNumber; // 고객 전화번호
 

--- a/src/main/java/com/mobility/api/domain/dispatch/service/DispatcherService.java
+++ b/src/main/java/com/mobility/api/domain/dispatch/service/DispatcherService.java
@@ -3,7 +3,7 @@ package com.mobility.api.domain.dispatch.service;
 import com.mobility.api.domain.dispatch.dto.response.DispatchCancelRes;
 import com.mobility.api.domain.dispatch.entity.Dispatch;
 import com.mobility.api.domain.dispatch.repository.DispatchRepository;
-import com.mobility.api.domain.dispatch.dto.response.DispatchRes;
+import com.mobility.api.domain.dispatch.dto.response.DispatchAssignCompleteRes;
 import com.mobility.api.domain.transporter.entity.Transporter;
 import com.mobility.api.domain.transporter.repository.TransporterRepository;
 import com.mobility.api.global.exception.GlobalException;
@@ -22,7 +22,7 @@ public class DispatcherService {
     private final TransporterRepository transporterRepository;
 
     @Transactional
-    public DispatchRes assignDispatch(Long dispatchId, Long transporterId) {
+    public DispatchAssignCompleteRes assignDispatch(Long dispatchId, Long transporterId) {
 
         // 1. 기사 정보 조회
         Transporter transporter = transporterRepository.findById(transporterId)
@@ -35,7 +35,7 @@ public class DispatcherService {
         // 3. 배차 할당
         dispatch.assignDispatch(transporter);
 
-        return DispatchRes.from(dispatch);
+        return DispatchAssignCompleteRes.from(dispatch);
     }
 
     @Transactional
@@ -55,7 +55,7 @@ public class DispatcherService {
     }
 
     @Transactional
-    public DispatchRes completeDispatch(Long dispatchId, Long transporterId) {
+    public DispatchAssignCompleteRes completeDispatch(Long dispatchId, Long transporterId) {
 
         // 1. 기사 정보 조회
         Transporter transporter = transporterRepository.findById(transporterId)
@@ -67,6 +67,6 @@ public class DispatcherService {
 
         dispatch.completeDispatch(transporter);
 
-        return DispatchRes.from(dispatch);
+        return DispatchAssignCompleteRes.from(dispatch);
     }
 }

--- a/src/main/java/com/mobility/api/domain/transporter/controller/TransporterV1Controller.java
+++ b/src/main/java/com/mobility/api/domain/transporter/controller/TransporterV1Controller.java
@@ -1,7 +1,7 @@
 package com.mobility.api.domain.transporter.controller;
 
 import com.mobility.api.domain.dispatch.dto.response.DispatchCancelRes;
-import com.mobility.api.domain.dispatch.dto.response.DispatchRes;
+import com.mobility.api.domain.dispatch.dto.response.DispatchAssignCompleteRes;
 import com.mobility.api.domain.dispatch.service.DispatcherService;
 import com.mobility.api.domain.transporter.dto.request.LocationUpdateReq;
 import com.mobility.api.domain.transporter.dto.response.LocationUpdateRes;
@@ -16,7 +16,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @Slf4j
@@ -31,7 +30,7 @@ public class TransporterV1Controller {
 
     @Operation(summary = "배차 할당", description = "")
     @PatchMapping("/dispatch-assign/{dispatchId}")
-    public CommonResponse<DispatchRes> assignDispatch(
+    public CommonResponse<DispatchAssignCompleteRes> assignDispatch(
             @PathVariable Long dispatchId, @CurrentUser Transporter transporter) {
 
         Long transporterId = getValidatedTransporterId(transporter);
@@ -51,7 +50,7 @@ public class TransporterV1Controller {
 
     @Operation(summary = "배차 완료", description = "")
     @PatchMapping("/dispatch-complete/{dispatchId}")
-    public CommonResponse<DispatchRes> completeDispatch(
+    public CommonResponse<DispatchAssignCompleteRes> completeDispatch(
             @PathVariable Long dispatchId, @CurrentUser Transporter transporter) {
 
         Long transporterId = getValidatedTransporterId(transporter);
@@ -68,7 +67,7 @@ public class TransporterV1Controller {
         return transporterId;
     }
 
-    /*
+    /**
         ** 기사 위치 정보 수집 관련
      */
     @Operation(summary = "기사 실시간 위치 업데이트", description = "기사 앱에서 전송된 위도(latitude), 경도(longitude) 정보를 저장")
@@ -83,4 +82,8 @@ public class TransporterV1Controller {
 
         return CommonResponse.success(response);
     }
+
+    /**
+     * 기사의 배차 리스트 정렬 등을 위해, 현재 기사 위치 기준으로 배차
+     */
 }

--- a/src/main/java/com/mobility/api/domain/transporter/dto/TransporterDistanceProjection.java
+++ b/src/main/java/com/mobility/api/domain/transporter/dto/TransporterDistanceProjection.java
@@ -1,0 +1,12 @@
+package com.mobility.api.domain.transporter.dto;
+
+/**
+ * Native Query 결과를 매핑할 인터페이스
+ */
+
+public interface TransporterDistanceProjection {
+    Long getId();
+    String getName();
+    String getPhone();
+    Double getDistanceInMeters(); // DB에서 계산된 미터 단위 거리
+}

--- a/src/main/java/com/mobility/api/domain/transporter/dto/response/TransporterMatchResponse.java
+++ b/src/main/java/com/mobility/api/domain/transporter/dto/response/TransporterMatchResponse.java
@@ -1,0 +1,32 @@
+package com.mobility.api.domain.transporter.dto.response;
+
+import com.mobility.api.domain.transporter.dto.TransporterDistanceProjection;
+import lombok.Builder;
+
+/**
+ * Projection의 미터 값을 받아 km로 변환하여 프론트에 전달
+ */
+
+@Builder
+public record TransporterMatchResponse(
+        Long transporterId,
+        String name,
+        String phone,
+        Double distanceKm // km 단위
+) {
+    public static TransporterMatchResponse from(TransporterDistanceProjection proj) {
+        // 미터(m) -> 킬로미터(km) 변환
+        // 값이 없으면 0.0 처리
+        double meters = proj.getDistanceInMeters() != null ? proj.getDistanceInMeters() : 0.0;
+
+        // 1000으로 나누고, 소수점 둘째 자리까지 반올림 (예: 1.25 km)
+        double km = Math.round((meters / 1000.0) * 100.0) / 100.0;
+
+        return TransporterMatchResponse.builder()
+                .transporterId(proj.getId())
+                .name(proj.getName())
+                .phone(proj.getPhone())
+                .distanceKm(km)
+                .build();
+    }
+}

--- a/src/main/java/com/mobility/api/domain/transporter/entity/Transporter.java
+++ b/src/main/java/com/mobility/api/domain/transporter/entity/Transporter.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
+import org.locationtech.jts.geom.Point;
 
 import java.time.LocalDateTime;
 
@@ -25,6 +26,11 @@ public class Transporter {
 
     @Column(name = "phone")
     private String phone;
+
+    // 실시간 위치 검색용 필드 (PostGIS Point)
+    // columnDefinition을 통해 SRID 4326(위경도)임을 명시
+    @Column(name = "current_location", columnDefinition = "geometry(Point, 4326)")
+    private Point currentLocation;
 
     @Column(name = "is_auto_dispatch")
     private boolean isAutoDispatch;

--- a/src/main/java/com/mobility/api/domain/transporter/repository/TransporterRepository.java
+++ b/src/main/java/com/mobility/api/domain/transporter/repository/TransporterRepository.java
@@ -1,7 +1,34 @@
 package com.mobility.api.domain.transporter.repository;
 
+import com.mobility.api.domain.transporter.dto.TransporterDistanceProjection;
 import com.mobility.api.domain.transporter.entity.Transporter;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface TransporterRepository extends JpaRepository<Transporter, Long> {
+
+    /**
+     * PostGIS의 ST_DistanceSphere를 사용해 미터 단위 거리를 계산
+     * 특정 좌표(lat, lon) 기준, 반경(radiusMeters) 내의 기사를 거리순 조회
+     */
+    @Query(value = """
+        SELECT t.transporter_id as id, 
+               t.name, 
+               t.phone,
+               ST_DistanceSphere(t.current_location, ST_SetSRID(ST_MakePoint(:lon, :lat), 4326)) as distanceInMeters
+        FROM transporters t
+        WHERE t.current_location IS NOT NULL
+          -- PostGIS 반경 검색 함수 (인덱스 활용)
+          AND ST_DWithin(t.current_location::geography, ST_SetSRID(ST_MakePoint(:lon, :lat), 4326)::geography, :radiusMeters)
+        ORDER BY distanceInMeters ASC
+        """, nativeQuery = true)
+    List<TransporterDistanceProjection> findNearbyTransporters(
+            @Param("lat") double lat,
+            @Param("lon") double lon,
+            @Param("radiusMeters") double radiusMeters
+    );
+
 }

--- a/src/main/java/com/mobility/api/domain/transporter/service/TransporterService.java
+++ b/src/main/java/com/mobility/api/domain/transporter/service/TransporterService.java
@@ -1,0 +1,29 @@
+package com.mobility.api.domain.transporter.service;
+
+import com.mobility.api.domain.transporter.dto.response.TransporterMatchResponse;
+import com.mobility.api.domain.transporter.repository.TransporterRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TransporterService {
+
+    private final TransporterRepository transporterRepository;
+
+    // 검색 반경 (미터 단위로 변환하여 사용)
+    private static final double SEARCH_RADIUS_METERS = 10000.0; // 10km
+
+    public List<TransporterMatchResponse> findNearbyTransporters(double lat, double lon) {
+        // Repository 호출 (미터 단위 반경 전달)
+        return transporterRepository.findNearbyTransporters(lat, lon, SEARCH_RADIUS_METERS)
+                .stream()
+                .map(TransporterMatchResponse::from) // km로 변환
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/mobility/api/global/response/ResultCode.java
+++ b/src/main/java/com/mobility/api/global/response/ResultCode.java
@@ -29,6 +29,7 @@ public enum ResultCode {
     CANNOT_CANCEL_DISPATCH(HttpStatus.BAD_REQUEST, 2007, "배차를 취소할 수 없습니다"),
     CANNOT_COMPLETE_DISPATCH(HttpStatus.BAD_REQUEST, 2008, "배차를 완료할 수 없습니다"),
     DISPATCH_NOT_ASSIGNED(HttpStatus.NOT_FOUND, 2009, "배차 상태가 ASSIGNED이 아닙니다."),
+    DISPATCH_NOT_FOUND(HttpStatus.NOT_FOUND, 2010, "배차를 찾을 수 없습니다."),
 
     /**
      * 3000번대 (기사 관련)

--- a/src/test/java/com/mobility/api/domain/dispatch/controller/DispatchV1ControllerTest.java
+++ b/src/test/java/com/mobility/api/domain/dispatch/controller/DispatchV1ControllerTest.java
@@ -1,0 +1,134 @@
+package com.mobility.api.domain.dispatch.controller;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.mobility.api.domain.dispatch.entity.Dispatch;
+import com.mobility.api.domain.dispatch.repository.DispatchRepository;
+import com.mobility.api.domain.transporter.dto.response.TransporterMatchResponse;
+import com.mobility.api.domain.transporter.repository.TransporterRepository;
+import com.mobility.api.domain.transporter.service.TransporterService;
+import com.mobility.api.global.exception.GlobalException;
+import com.mobility.api.global.response.ResultCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WithMockUser
+@WebMvcTest(DispatchV1Controller.class)
+class DispatchV1ControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private DispatchRepository dispatchRepository;
+
+    @MockitoBean
+    private TransporterService transporterService;
+
+    @MockitoBean
+    private TransporterRepository transporterRepository;
+
+    @Test
+    @DisplayName("[API] 배차 주변 기사 조회 - 성공 (200 OK)")
+    void getNearbyDrivers_ApiSuccess() throws Exception {
+        // given
+        Long dispatchId = 1L;
+
+        // 1. Mock 배차 데이터 (강남역)
+        Dispatch mockDispatch = Dispatch.builder()
+                .id(dispatchId)
+                .startLatitude(37.4980)
+                .startLongitude(127.0276)
+                .build();
+
+        // 2. Mock 기사 응답 데이터 (2명)
+        List<TransporterMatchResponse> mockDrivers = List.of(
+                TransporterMatchResponse.builder()
+                        .transporterId(101L)
+                        .name("김기사")
+                        .phone("010-1234-5678")
+                        .distanceKm(1.52)
+                        .build(),
+                TransporterMatchResponse.builder()
+                        .transporterId(102L)
+                        .name("이기사")
+                        .phone("010-9876-5432")
+                        .distanceKm(3.05)
+                        .build()
+        );
+
+        // 3. Stubbing (가짜 동작 정의)
+        given(dispatchRepository.findById(dispatchId)).willReturn(Optional.of(mockDispatch));
+        given(transporterService.findNearbyTransporters(anyDouble(), anyDouble()))
+                .willReturn(mockDrivers);
+
+        // when & then (요청 및 검증)
+        mockMvc.perform(get("/api/v1/dispatch/{dispatchId}/nearby-drivers", dispatchId)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print()) // 콘솔에 요청/응답 로그 출력
+                .andExpect(status().isOk())
+
+                // CommonResponse 구조 검증
+                .andExpect(jsonPath("$.statusCode").value(0))
+                .andExpect(jsonPath("$.message").value("정상 처리 되었습니다."))
+
+                // 데이터(List) 검증
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data.length()").value(2))
+
+                // 첫 번째 기사 데이터 확인
+                .andExpect(jsonPath("$.data[0].transporterId").value(101L))
+                .andExpect(jsonPath("$.data[0].name").value("김기사"))
+                .andExpect(jsonPath("$.data[0].distanceKm").value(1.52))
+
+                // 두 번째 기사 데이터 확인
+                .andExpect(jsonPath("$.data[1].transporterId").value(102L))
+                .andExpect(jsonPath("$.data[1].name").value("이기사"));
+    }
+
+    @Test
+    @DisplayName("[API] 존재하지 않는 배차 조회 시 - 실패 (예외 발생)")
+    void getNearbyDrivers_ApiFail_NotFound() throws Exception {
+        // given
+        Long invalidId = 9999L;
+
+        // 배차가 없어서 Optional.empty() 반환
+        given(dispatchRepository.findById(invalidId)).willReturn(Optional.empty());
+
+        // when & then
+        mockMvc.perform(get("/api/v1/dispatch/{dispatchId}/nearby-drivers", invalidId)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                // GlobalExceptionHandler 설정에 따라 상태 코드는 달라질 수 있음 (보통 404 Not Found 또는 400 Bad Request)
+                // 여기서는 예외가 발생했는지, 그리고 우리가 정의한 ResultCode와 관련된 값이 나오는지 확인해야 함
+                .andExpect(result -> {
+                    Exception resolvedException = result.getResolvedException();
+                    if (resolvedException instanceof GlobalException) {
+                        GlobalException ex = (GlobalException) resolvedException;
+                        // 예외 코드가 DISPATCH_NOT_FOUND 인지 확인
+                        if (ex.getResultCode() != ResultCode.DISPATCH_NOT_FOUND) {
+                            throw new AssertionError("기대했던 예외 코드가 아닙니다.");
+                        }
+                    } else {
+                        // GlobalException이 아닌 다른 예외가 발생했거나 예외 처리가 안 된 경우
+                        // (프로젝트 설정에 따라 수정 필요)
+                    }
+                });
+    }
+}

--- a/src/test/java/com/mobility/api/domain/transporter/service/TransporterServiceTest.java
+++ b/src/test/java/com/mobility/api/domain/transporter/service/TransporterServiceTest.java
@@ -1,0 +1,66 @@
+package com.mobility.api.domain.transporter.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.mobility.api.domain.transporter.dto.TransporterDistanceProjection;
+import com.mobility.api.domain.transporter.dto.response.TransporterMatchResponse;
+import com.mobility.api.domain.transporter.repository.TransporterRepository;
+//import com.mobility.api.global.util.DispatchMockFactory; // 위에서 만든 MockFactory import
+import com.mobility.api.global.util.DispatchMockFactory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class TransporterServiceTest {
+
+    @Mock
+    private TransporterRepository transporterRepository;
+
+    @InjectMocks
+    private TransporterService transporterService;
+
+    @Test
+    @DisplayName("기사 위치 검색 시 미터(m) 단위 거리가 km 단위로 소수점 반올림되어 반환된다.")
+    void verifyDistanceConversion() {
+        // given
+        double lat = 37.5547;
+        double lon = 126.9707;
+
+        // Mock 데이터 생성 (Factory 활용)
+        // 기사1: 1523m 거리 -> 예상 1.52km
+        TransporterDistanceProjection driver1 =
+                DispatchMockFactory.createTransporterProjection(101L, "김기사", 1523.0);
+
+        // 기사2: 500m 거리 -> 예상 0.5km
+        TransporterDistanceProjection driver2 =
+                DispatchMockFactory.createTransporterProjection(102L, "이기사", 500.0);
+
+        // Repository Mocking: findNearbyTransporters 호출 시 위 리스트 반환
+        given(transporterRepository.findNearbyTransporters(anyDouble(), anyDouble(), anyDouble()))
+                .willReturn(List.of(driver1, driver2));
+
+        // when
+        List<TransporterMatchResponse> result = transporterService.findNearbyTransporters(lat, lon);
+
+        // then
+        assertThat(result).hasSize(2);
+
+        // 첫 번째 기사 검증 (1523m -> 1.52km)
+        assertThat(result.get(0).transporterId()).isEqualTo(101L);
+        assertThat(result.get(0).distanceKm()).isEqualTo(1.52);
+
+        // 두 번째 기사 검증 (500m -> 0.5km)
+        assertThat(result.get(1).transporterId()).isEqualTo(102L);
+        assertThat(result.get(1).distanceKm()).isEqualTo(0.5);
+    }
+}

--- a/src/test/java/com/mobility/api/global/util/DispatchMockFactory.java
+++ b/src/test/java/com/mobility/api/global/util/DispatchMockFactory.java
@@ -1,0 +1,52 @@
+package com.mobility.api.global.util;
+
+import com.mobility.api.domain.dispatch.entity.Dispatch;
+import com.mobility.api.domain.transporter.dto.TransporterDistanceProjection;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.PrecisionModel;
+import org.mockito.Mockito;
+
+public class DispatchMockFactory {
+
+    private static final GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(), 4326);
+
+    /**
+     * 가짜 배차(Dispatch) 엔티티 생성
+     * 예: 서울역 (37.5547, 126.9707)
+     */
+    public static Dispatch createDispatch(Long id) {
+        return Dispatch.builder()
+                .id(id)
+                .startLocation("서울역")
+                .startLatitude(37.5547)  // 서울역 위도
+                .startLongitude(126.9707) // 서울역 경도
+                .build();
+    }
+
+    /**
+     * 가짜 기사 위치 정보(Projection) 생성 - Interface Mocking
+     * 예: 남산타워 기사 (서울역에서 약 1.5km 거리)
+     */
+    public static TransporterDistanceProjection createTransporterProjection(
+            Long id, String name, double distanceMeters) {
+
+        // Interface는 new로 생성할 수 없으므로 Mockito.mock() 사용
+        TransporterDistanceProjection mock = Mockito.mock(TransporterDistanceProjection.class);
+
+        Mockito.when(mock.getId()).thenReturn(id);
+        Mockito.when(mock.getName()).thenReturn(name);
+        Mockito.when(mock.getPhone()).thenReturn("010-1234-5678");
+        Mockito.when(mock.getDistanceInMeters()).thenReturn(distanceMeters);
+
+        return mock;
+    }
+
+    /**
+     * (참고용) 실제 Point 객체 생성이 필요할 경우 사용
+     */
+    public static Point createPoint(double lat, double lon) {
+        return geometryFactory.createPoint(new Coordinate(lon, lat));
+    }
+}


### PR DESCRIPTION
## 관련 이슈
#35 

## 📌 작업 개요
배차 등록 후, 반경 내 존재하는 기사 가까운 순으로 조회

Transporter Domain
- Entity: 실시간 위치 저장을 위한 currentLocation (Geometry Point) 필드 추가
- Repository: PostGIS(ST_DistanceSphere, ST_DWithin)를 활용한 반경 검색 Native Query 구현
- DTO: DB 조회 결과(m)를 응답용(km)으로 변환하는 TransporterMatchResponse 구현
- Service: 반경 50km 내 기사 검색 로직 구현 (TransporterService)

Dispatch Domain
- Controller: GET /api/v1/dispatch/{dispatchId}/nearby-drivers 엔드포인트 추가
- Logic: 배차 ID로 출발지 좌표 조회 후 TransporterService 호출

## ✨ 기타 참고 사항
<!-- 리뷰어가 참고해야 할 사항이나, 보완 예정인 내용이 있다면 작성해주세요 -->
- 

## ✅ 체크리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] `application.yml` 파일을 수정했다면, Notion에 업로드, github security 수정 및 공유했어요.
- [x] 로컬 서버에서 정상 동작을 확인했어요. (main, test)
- [x] 불필요한 코드는 삭제했어요.