### PR TITLE
[#40] feat: 배차 등록시 거리순 알림 전송 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,9 @@ dependencies {
 	// Spring Security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 
+	// WebSocket
+	implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
 	// Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/com/mobility/api/domain/dispatch/dto/request/DispatchResponseReq.java
+++ b/src/main/java/com/mobility/api/domain/dispatch/dto/request/DispatchResponseReq.java
@@ -1,0 +1,13 @@
+package com.mobility.api.domain.dispatch.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * 배차 응답 요청 DTO
+ * - 기사가 WebSocket으로 수락/거절할 때 사용
+ */
+public record DispatchResponseReq(
+        @NotNull(message = "offerId는 필수입니다.")
+        Long offerId
+) {
+}

--- a/src/main/java/com/mobility/api/domain/dispatch/dto/response/DispatchOfferRes.java
+++ b/src/main/java/com/mobility/api/domain/dispatch/dto/response/DispatchOfferRes.java
@@ -1,0 +1,39 @@
+package com.mobility.api.domain.dispatch.dto.response;
+
+import com.mobility.api.domain.dispatch.entity.DispatchOffer;
+import com.mobility.api.domain.dispatch.enums.OfferStatus;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+/**
+ * 배차 제안 응답 DTO
+ * - 배차 제안 이력 조회 시 사용
+ */
+@Builder
+public record DispatchOfferRes(
+        Long offerId,               // 제안 ID
+        Long dispatchId,            // 배차 ID
+        Long transporterId,         // 기사 ID
+        String transporterName,     // 기사 이름
+        OfferStatus status,         // 제안 상태
+        Integer sequence,           // 순서
+        LocalDateTime offeredAt,    // 제안 시각
+        LocalDateTime respondedAt   // 응답 시각
+) {
+    /**
+     * DispatchOffer 엔티티로부터 DTO 생성
+     */
+    public static DispatchOfferRes from(DispatchOffer offer) {
+        return DispatchOfferRes.builder()
+                .offerId(offer.getId())
+                .dispatchId(offer.getDispatch().getId())
+                .transporterId(offer.getTransporter().getId())
+                .transporterName(offer.getTransporter().getName())
+                .status(offer.getStatus())
+                .sequence(offer.getSequence())
+                .offeredAt(offer.getOfferedAt())
+                .respondedAt(offer.getRespondedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/mobility/api/domain/dispatch/dto/websocket/DispatchOfferNotification.java
+++ b/src/main/java/com/mobility/api/domain/dispatch/dto/websocket/DispatchOfferNotification.java
@@ -1,0 +1,51 @@
+package com.mobility.api.domain.dispatch.dto.websocket;
+
+import com.mobility.api.domain.dispatch.entity.Dispatch;
+import com.mobility.api.domain.dispatch.entity.DispatchOffer;
+import com.mobility.api.domain.dispatch.enums.ServiceType;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+/**
+ * 배차 알림 WebSocket 메시지
+ * - 서버 → 기사로 전송되는 배차 제안 알림
+ */
+@Builder
+public record DispatchOfferNotification(
+        Long offerId,                       // 제안 ID
+        Long dispatchId,                    // 배차 ID
+        String startLocation,               // 출발지
+        Double startLatitude,               // 출발지 위도
+        Double startLongitude,              // 출발지 경도
+        String destinationLocation,         // 도착지
+        Double destinationLatitude,         // 도착지 위도
+        Double destinationLongitude,        // 도착지 경도
+        Integer charge,                     // 요금
+        ServiceType serviceType,            // 서비스 타입 (DELIVERY/DRIVER)
+        Integer sequence,                   // 순서 (1~10)
+        Double distanceKm,                  // 거리 (km)
+        LocalDateTime offeredAt             // 제안 시각
+) {
+    /**
+     * DispatchOffer 엔티티로부터 DTO 생성
+     */
+    public static DispatchOfferNotification from(DispatchOffer offer, Double distanceKm) {
+        Dispatch dispatch = offer.getDispatch();
+        return DispatchOfferNotification.builder()
+                .offerId(offer.getId())
+                .dispatchId(dispatch.getId())
+                .startLocation(dispatch.getStartLocation())
+                .startLatitude(dispatch.getStartLatitude())
+                .startLongitude(dispatch.getStartLongitude())
+                .destinationLocation(dispatch.getDestinationLocation())
+                .destinationLatitude(dispatch.getDestinationLatitude())
+                .destinationLongitude(dispatch.getDestinationLongitude())
+                .charge(dispatch.getCharge())
+                .serviceType(dispatch.getService())
+                .sequence(offer.getSequence())
+                .distanceKm(distanceKm)
+                .offeredAt(offer.getOfferedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/mobility/api/domain/dispatch/entity/DispatchOffer.java
+++ b/src/main/java/com/mobility/api/domain/dispatch/entity/DispatchOffer.java
@@ -1,0 +1,81 @@
+package com.mobility.api.domain.dispatch.entity;
+
+import com.mobility.api.domain.dispatch.enums.OfferStatus;
+import com.mobility.api.domain.transporter.entity.Transporter;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+/**
+ * 배차 제안 엔티티
+ * - 배차가 등록되면 거리순으로 기사에게 순차적으로 제안
+ * - 각 제안의 이력을 저장하여 통계 및 분석에 활용
+ */
+@Entity
+@Table(name = "dispatch_offer")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class DispatchOffer {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "dispatch_id", nullable = false)
+    private Dispatch dispatch;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "transporter_id", nullable = false)
+    private Transporter transporter;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private OfferStatus status;
+
+    @Column(nullable = false)
+    private Integer sequence;  // 순서 (1~10)
+
+    @Column(nullable = false)
+    private LocalDateTime offeredAt;  // 제안 시각
+
+    @Column
+    private LocalDateTime respondedAt;  // 응답 시각 (수락/거절/타임아웃)
+
+    @PrePersist
+    protected void onCreate() {
+        if (offeredAt == null) {
+            offeredAt = LocalDateTime.now();
+        }
+        if (status == null) {
+            status = OfferStatus.PENDING;
+        }
+    }
+
+    /**
+     * 배차 수락 처리
+     */
+    public void accept() {
+        this.status = OfferStatus.ACCEPTED;
+        this.respondedAt = LocalDateTime.now();
+    }
+
+    /**
+     * 배차 거절 처리
+     */
+    public void reject() {
+        this.status = OfferStatus.REJECTED;
+        this.respondedAt = LocalDateTime.now();
+    }
+
+    /**
+     * 타임아웃 처리 (5초 미응답)
+     */
+    public void timeout() {
+        this.status = OfferStatus.TIMEOUT;
+        this.respondedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/mobility/api/domain/dispatch/enums/OfferResult.java
+++ b/src/main/java/com/mobility/api/domain/dispatch/enums/OfferResult.java
@@ -1,0 +1,11 @@
+package com.mobility.api.domain.dispatch.enums;
+
+/**
+ * 배차 제안 결과
+ * - 타임아웃 처리 로직에서 사용
+ */
+public enum OfferResult {
+    ACCEPTED,   // 수락됨
+    REJECTED,   // 거절됨
+    TIMEOUT     // 타임아웃 (5초 미응답)
+}

--- a/src/main/java/com/mobility/api/domain/dispatch/enums/OfferStatus.java
+++ b/src/main/java/com/mobility/api/domain/dispatch/enums/OfferStatus.java
@@ -1,0 +1,11 @@
+package com.mobility.api.domain.dispatch.enums;
+
+/**
+ * 배차 제안 상태
+ */
+public enum OfferStatus {
+    PENDING,    // 대기 중 (알림 전송 완료, 응답 대기)
+    ACCEPTED,   // 수락
+    REJECTED,   // 거절
+    TIMEOUT     // 타임아웃 (5초 미응답)
+}

--- a/src/main/java/com/mobility/api/domain/dispatch/repository/DispatchOfferRepository.java
+++ b/src/main/java/com/mobility/api/domain/dispatch/repository/DispatchOfferRepository.java
@@ -1,0 +1,39 @@
+package com.mobility.api.domain.dispatch.repository;
+
+import com.mobility.api.domain.dispatch.entity.DispatchOffer;
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.QueryHint;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface DispatchOfferRepository extends JpaRepository<DispatchOffer, Long> {
+
+    /**
+     * 특정 배차에 대한 모든 제안 조회 (순서대로)
+     * - 배차 이력 확인용
+     */
+    List<DispatchOffer> findByDispatchIdOrderBySequenceAsc(Long dispatchId);
+
+    /**
+     * 제안 조회 with 비관적 락
+     * - 동시성 제어: 여러 기사가 동시에 응답하는 것을 방지
+     * - 3초 타임아웃
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints({@QueryHint(name = "jakarta.persistence.lock.timeout", value = "3000")})
+    @Query("SELECT o FROM DispatchOffer o WHERE o.id = :offerId")
+    Optional<DispatchOffer> findByIdWithLock(@Param("offerId") Long offerId);
+
+    /**
+     * 기사의 PENDING 상태 제안 개수 조회
+     * - 중복 알림 방지용 (필요 시 사용)
+     */
+    @Query("SELECT COUNT(o) FROM DispatchOffer o WHERE o.transporter.id = :transporterId AND o.status = 'PENDING'")
+    int countPendingOffersByTransporter(@Param("transporterId") Long transporterId);
+}

--- a/src/main/java/com/mobility/api/domain/dispatch/service/AutoDispatchService.java
+++ b/src/main/java/com/mobility/api/domain/dispatch/service/AutoDispatchService.java
@@ -1,0 +1,355 @@
+package com.mobility.api.domain.dispatch.service;
+
+import com.mobility.api.domain.dispatch.dto.websocket.DispatchOfferNotification;
+import com.mobility.api.domain.dispatch.entity.Dispatch;
+import com.mobility.api.domain.dispatch.entity.DispatchOffer;
+import com.mobility.api.domain.dispatch.enums.OfferResult;
+import com.mobility.api.domain.dispatch.enums.OfferStatus;
+import com.mobility.api.domain.dispatch.enums.StatusType;
+import com.mobility.api.domain.dispatch.repository.DispatchOfferRepository;
+import com.mobility.api.domain.dispatch.repository.DispatchRepository;
+import com.mobility.api.domain.transporter.dto.TransporterDistanceProjection;
+import com.mobility.api.domain.transporter.entity.Transporter;
+import com.mobility.api.domain.transporter.repository.TransporterRepository;
+import com.mobility.api.global.exception.GlobalException;
+import com.mobility.api.global.response.ResultCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+/**
+ * 자동 배차 알림 서비스
+ * - 배차 등록 시 거리순으로 기사에게 순차적으로 알림 전송
+ * - WebSocket (STOMP)를 통한 실시간 알림
+ * - 5초 타임아웃 처리
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AutoDispatchService {
+
+    private final DispatchRepository dispatchRepository;
+    private final DispatchOfferRepository offerRepository;
+    private final TransporterRepository transporterRepository;
+    private final SimpMessagingTemplate messagingTemplate;
+
+    @Qualifier("dispatchTimeoutScheduler")
+    private final ScheduledExecutorService scheduledExecutor;
+
+    // offerId -> CompletableFuture 매핑 (응답 대기용)
+    private final ConcurrentHashMap<Long, CompletableFuture<OfferResult>> offerFutureMap = new ConcurrentHashMap<>();
+
+    /**
+     * 순차 알림 전송 시작 (비동기)
+     * - 거리순으로 최대 10명의 기사에게 순차적으로 알림
+     * - 각 기사당 5초 응답 대기
+     * - 수락 시 종료, 거절/타임아웃 시 다음 기사에게 전송
+     *
+     * @param dispatchId 배차 ID
+     */
+    @Async("autoDispatchExecutor")
+    public void startSequentialNotification(Long dispatchId) {
+        log.info("[AutoDispatch] 순차 알림 시작 - dispatchId: {}", dispatchId);
+
+        try {
+            // 1. 배차 정보 조회
+            Dispatch dispatch = dispatchRepository.findById(dispatchId)
+                    .orElseThrow(() -> new GlobalException(ResultCode.NOT_FOUND_DISPATCH));
+
+            // 2. 적격 기사 조회 (isAutoDispatch = true, 거리순, 최대 10명)
+            List<Transporter> eligibleDrivers = findEligibleDrivers(dispatch);
+
+            if (eligibleDrivers.isEmpty()) {
+                log.info("[AutoDispatch] 적격 기사 없음 - dispatchId: {}", dispatchId);
+                return;
+            }
+
+            log.info("[AutoDispatch] 적격 기사 {}명 발견 - dispatchId: {}", eligibleDrivers.size(), dispatchId);
+
+            // 3. 순차적으로 알림 전송
+            for (int i = 0; i < eligibleDrivers.size(); i++) {
+                Transporter driver = eligibleDrivers.get(i);
+
+                // 배차 상태 재확인 (이미 할당되었을 수 있음)
+                dispatch = dispatchRepository.findById(dispatchId)
+                        .orElseThrow(() -> new GlobalException(ResultCode.NOT_FOUND_DISPATCH));
+
+                if (dispatch.getStatus() != StatusType.OPEN) {
+                    log.info("[AutoDispatch] 배차가 더 이상 OPEN 상태가 아님. 종료 - dispatchId: {}, status: {}",
+                            dispatchId, dispatch.getStatus());
+                    break;
+                }
+
+                // 3-1. DispatchOffer 생성 (별도 트랜잭션)
+                DispatchOffer offer = createOfferInTransaction(dispatch, driver, i + 1);
+
+                // 3-2. WebSocket 알림 전송
+                Double distanceKm = calculateDistanceKm(dispatch, driver);
+                DispatchOfferNotification notification = DispatchOfferNotification.from(offer, distanceKm);
+                sendNotificationToDriver(driver.getId(), notification);
+
+                log.info("[AutoDispatch] 알림 전송 완료 - offerId: {}, transporterId: {}, sequence: {}",
+                        offer.getId(), driver.getId(), i + 1);
+
+                // 3-3. 5초 대기 (응답 대기)
+                CompletableFuture<OfferResult> future = waitForResponseWithTimeout(offer.getId());
+
+                try {
+                    OfferResult result = future.get(); // Blocking
+
+                    if (result == OfferResult.ACCEPTED) {
+                        log.info("[AutoDispatch] 기사가 수락함. 프로세스 종료 - dispatchId: {}, transporterId: {}",
+                                dispatchId, driver.getId());
+                        return; // 프로세스 종료
+                    } else {
+                        log.info("[AutoDispatch] 기사가 거절/타임아웃. 다음 기사에게 전송 - dispatchId: {}, result: {}",
+                                dispatchId, result);
+                        // continue to next driver
+                    }
+
+                } catch (Exception e) {
+                    log.error("[AutoDispatch] 응답 대기 중 오류 발생 - offerId: {}", offer.getId(), e);
+                    // continue to next driver
+                }
+            }
+
+            // 4. 10명 모두 거절/미응답
+            log.info("[AutoDispatch] 모든 기사가 거절/미응답. 배차는 OPEN 상태 유지 - dispatchId: {}", dispatchId);
+
+        } catch (Exception e) {
+            log.error("[AutoDispatch] 순차 알림 처리 중 오류 발생 - dispatchId: {}", dispatchId, e);
+        }
+    }
+
+    /**
+     * 배차 수락 처리
+     *
+     * @param offerId       제안 ID
+     * @param transporterId 기사 ID
+     */
+    @Transactional
+    public void handleAccept(Long offerId, Long transporterId) {
+        log.info("[AutoDispatch] 수락 처리 시작 - offerId: {}, transporterId: {}", offerId, transporterId);
+
+        // 1. Offer 조회 with Lock
+        DispatchOffer offer = offerRepository.findByIdWithLock(offerId)
+                .orElseThrow(() -> new GlobalException(ResultCode.OFFER_NOT_FOUND));
+
+        // 2. 이미 응답한 제안인지 확인
+        if (offer.getStatus() != OfferStatus.PENDING) {
+            throw new GlobalException(ResultCode.OFFER_ALREADY_RESPONDED);
+        }
+
+        // 3. 기사 본인 확인
+        if (!offer.getTransporter().getId().equals(transporterId)) {
+            throw new GlobalException(ResultCode.FORBIDDEN);
+        }
+
+        // 4. 배차 조회 with Lock
+        Dispatch dispatch = dispatchRepository.findByIdWithPessimisticLock(offer.getDispatch().getId())
+                .orElseThrow(() -> new GlobalException(ResultCode.NOT_FOUND_DISPATCH));
+
+        // 5. 배차 상태 확인 (이미 할당되었을 수 있음)
+        if (dispatch.getStatus() != StatusType.OPEN) {
+            // Offer는 거절로 처리
+            offer.reject();
+            offerRepository.save(offer);
+            throw new GlobalException(ResultCode.DISPATCH_ALREADY_ASSIGNED);
+        }
+
+        // 6. 배차 할당
+        Transporter transporter = offer.getTransporter();
+        dispatch.assignDispatch(transporter);
+        dispatchRepository.save(dispatch);
+
+        // 7. Offer 수락 처리
+        offer.accept();
+        offerRepository.save(offer);
+
+        // 8. CompletableFuture 완료 (타임아웃 취소)
+        completeOfferFuture(offerId, OfferResult.ACCEPTED);
+
+        log.info("[AutoDispatch] 배차 할당 완료 - dispatchId: {}, transporterId: {}", dispatch.getId(), transporterId);
+    }
+
+    /**
+     * 배차 거절 처리
+     *
+     * @param offerId       제안 ID
+     * @param transporterId 기사 ID
+     */
+    @Transactional
+    public void handleReject(Long offerId, Long transporterId) {
+        log.info("[AutoDispatch] 거절 처리 시작 - offerId: {}, transporterId: {}", offerId, transporterId);
+
+        // 1. Offer 조회 with Lock
+        DispatchOffer offer = offerRepository.findByIdWithLock(offerId)
+                .orElseThrow(() -> new GlobalException(ResultCode.OFFER_NOT_FOUND));
+
+        // 2. 이미 응답한 제안인지 확인
+        if (offer.getStatus() != OfferStatus.PENDING) {
+            throw new GlobalException(ResultCode.OFFER_ALREADY_RESPONDED);
+        }
+
+        // 3. 기사 본인 확인
+        if (!offer.getTransporter().getId().equals(transporterId)) {
+            throw new GlobalException(ResultCode.FORBIDDEN);
+        }
+
+        // 4. Offer 거절 처리
+        offer.reject();
+        offerRepository.save(offer);
+
+        // 5. CompletableFuture 완료
+        completeOfferFuture(offerId, OfferResult.REJECTED);
+
+        log.info("[AutoDispatch] 거절 처리 완료 - offerId: {}", offerId);
+    }
+
+    /**
+     * 적격 기사 조회
+     * - isAutoDispatch = true
+     * - 거리순 정렬
+     * - 최대 10명
+     */
+    @Transactional(readOnly = true)
+    protected List<Transporter> findEligibleDrivers(Dispatch dispatch) {
+        // 1. PostGIS 기반 거리순 조회 (50km 반경, 최대 10명)
+        List<TransporterDistanceProjection> projections = transporterRepository.findEligibleDriversForAutoDispatch(
+                dispatch.getStartLatitude(),
+                dispatch.getStartLongitude()
+        );
+
+        // 2. Projection -> Entity 변환 (순서 유지)
+        List<Long> transporterIds = projections.stream()
+                .map(TransporterDistanceProjection::getId)
+                .collect(Collectors.toList());
+
+        if (transporterIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        // 3. Entity 조회 (순서 유지)
+        Map<Long, Transporter> transporterMap = transporterRepository
+                .findAllById(transporterIds).stream()
+                .collect(Collectors.toMap(Transporter::getId, t -> t));
+
+        return transporterIds.stream()
+                .map(transporterMap::get)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 5초 타임아웃 처리
+     */
+    private CompletableFuture<OfferResult> waitForResponseWithTimeout(Long offerId) {
+        CompletableFuture<OfferResult> future = new CompletableFuture<>();
+
+        // Map에 저장 (WebSocket 응답 수신 시 complete 호출)
+        offerFutureMap.put(offerId, future);
+
+        // 5초 후 타임아웃 처리
+        scheduledExecutor.schedule(() -> {
+            CompletableFuture<OfferResult> f = offerFutureMap.remove(offerId);
+            if (f != null && !f.isDone()) {
+                f.complete(OfferResult.TIMEOUT);
+
+                // DB 업데이트 (타임아웃 처리)
+                updateOfferStatusToTimeout(offerId);
+            }
+        }, 5, TimeUnit.SECONDS);
+
+        return future;
+    }
+
+    /**
+     * CompletableFuture 완료 처리
+     */
+    private void completeOfferFuture(Long offerId, OfferResult result) {
+        CompletableFuture<OfferResult> future = offerFutureMap.remove(offerId);
+        if (future != null && !future.isDone()) {
+            future.complete(result);
+        }
+    }
+
+    /**
+     * 타임아웃 시 DB 업데이트
+     */
+    @Transactional
+    protected void updateOfferStatusToTimeout(Long offerId) {
+        offerRepository.findById(offerId).ifPresent(offer -> {
+            if (offer.getStatus() == OfferStatus.PENDING) {
+                offer.timeout();
+                offerRepository.save(offer);
+                log.info("[AutoDispatch] 타임아웃 처리 완료 - offerId: {}", offerId);
+            }
+        });
+    }
+
+    /**
+     * DispatchOffer 생성 (별도 트랜잭션)
+     */
+    @Transactional
+    protected DispatchOffer createOfferInTransaction(Dispatch dispatch, Transporter driver, int sequence) {
+        DispatchOffer offer = DispatchOffer.builder()
+                .dispatch(dispatch)
+                .transporter(driver)
+                .sequence(sequence)
+                .build();
+        return offerRepository.save(offer);
+    }
+
+    /**
+     * WebSocket으로 기사에게 알림 전송
+     */
+    private void sendNotificationToDriver(Long transporterId, DispatchOfferNotification notification) {
+        String destination = "/queue/" + transporterId + "/dispatch";
+        messagingTemplate.convertAndSend(destination, notification);
+        log.debug("[AutoDispatch] WebSocket 메시지 전송 - destination: {}, offerId: {}",
+                destination, notification.offerId());
+    }
+
+    /**
+     * 거리 계산 (km)
+     */
+    private Double calculateDistanceKm(Dispatch dispatch, Transporter driver) {
+        if (driver.getCurrentLocation() == null) {
+            return null;
+        }
+
+        double driverLat = driver.getCurrentLocation().getY();
+        double driverLon = driver.getCurrentLocation().getX();
+
+        return calculateDistance(dispatch.getStartLatitude(), dispatch.getStartLongitude(), driverLat, driverLon);
+    }
+
+    /**
+     * Haversine 공식을 사용한 거리 계산 (km 단위)
+     */
+    private Double calculateDistance(double startLat, double startLon, double endLat, double endLon) {
+        double earthRadiusKm = 6371.0;
+
+        double dLat = Math.toRadians(endLat - startLat);
+        double dLon = Math.toRadians(endLon - startLon);
+
+        double a = Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+                Math.cos(Math.toRadians(startLat)) * Math.cos(Math.toRadians(endLat)) *
+                        Math.sin(dLon / 2) * Math.sin(dLon / 2);
+
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+
+        return earthRadiusKm * c;
+    }
+}

--- a/src/main/java/com/mobility/api/domain/dispatch/websocket/DispatchWebSocketController.java
+++ b/src/main/java/com/mobility/api/domain/dispatch/websocket/DispatchWebSocketController.java
@@ -1,0 +1,86 @@
+package com.mobility.api.domain.dispatch.websocket;
+
+import com.mobility.api.domain.dispatch.dto.request.DispatchResponseReq;
+import com.mobility.api.domain.dispatch.service.AutoDispatchService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Controller;
+
+/**
+ * 배차 WebSocket 컨트롤러
+ * - 기사가 WebSocket (STOMP)로 배차 수락/거절 메시지를 보낼 때 처리
+ */
+@Controller
+@RequiredArgsConstructor
+@Slf4j
+public class DispatchWebSocketController {
+
+    private final AutoDispatchService autoDispatchService;
+
+    /**
+     * 배차 수락
+     * - 경로: /app/dispatch/accept
+     * - 기사가 배차 알림을 받고 수락 버튼을 누를 때 호출
+     *
+     * @param request       배차 응답 요청 (offerId 포함)
+     * @param transporterId 기사 ID (헤더에서 추출, dev/local: X-Temp-User-Id)
+     */
+    @MessageMapping("/dispatch/accept")
+    public void acceptDispatch(
+            @Payload DispatchResponseReq request,
+            @Header(value = "X-Temp-User-Id", required = false) String transporterId) {
+
+        log.info("[WebSocket] 배차 수락 요청 - offerId: {}, transporterId: {}", request.offerId(), transporterId);
+
+        try {
+            Long userId = parseTransporterId(transporterId);
+            autoDispatchService.handleAccept(request.offerId(), userId);
+            log.info("[WebSocket] 배차 수락 처리 완료 - offerId: {}", request.offerId());
+        } catch (Exception e) {
+            log.error("[WebSocket] 배차 수락 처리 실패 - offerId: {}", request.offerId(), e);
+            // 에러는 로깅만 하고, 클라이언트에게는 별도 응답 없음 (필요 시 /queue/{userId}/errors로 전송)
+        }
+    }
+
+    /**
+     * 배차 거절
+     * - 경로: /app/dispatch/reject
+     * - 기사가 배차 알림을 받고 거절 버튼을 누를 때 호출
+     *
+     * @param request       배차 응답 요청 (offerId 포함)
+     * @param transporterId 기사 ID (헤더에서 추출, dev/local: X-Temp-User-Id)
+     */
+    @MessageMapping("/dispatch/reject")
+    public void rejectDispatch(
+            @Payload DispatchResponseReq request,
+            @Header(value = "X-Temp-User-Id", required = false) String transporterId) {
+
+        log.info("[WebSocket] 배차 거절 요청 - offerId: {}, transporterId: {}", request.offerId(), transporterId);
+
+        try {
+            Long userId = parseTransporterId(transporterId);
+            autoDispatchService.handleReject(request.offerId(), userId);
+            log.info("[WebSocket] 배차 거절 처리 완료 - offerId: {}", request.offerId());
+        } catch (Exception e) {
+            log.error("[WebSocket] 배차 거절 처리 실패 - offerId: {}", request.offerId(), e);
+        }
+    }
+
+    /**
+     * transporterId 파싱
+     * - 헤더에서 받은 문자열을 Long으로 변환
+     */
+    private Long parseTransporterId(String transporterId) {
+        if (transporterId == null || transporterId.isBlank()) {
+            throw new IllegalArgumentException("transporterId is required");
+        }
+        try {
+            return Long.parseLong(transporterId);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Invalid transporterId: " + transporterId);
+        }
+    }
+}

--- a/src/main/java/com/mobility/api/domain/office/service/OfficeService.java
+++ b/src/main/java/com/mobility/api/domain/office/service/OfficeService.java
@@ -3,6 +3,7 @@ package com.mobility.api.domain.office.service;
 import com.mobility.api.domain.dispatch.entity.Dispatch;
 import com.mobility.api.domain.dispatch.enums.StatusType;
 import com.mobility.api.domain.dispatch.repository.DispatchRepository;
+import com.mobility.api.domain.dispatch.service.AutoDispatchService;
 import com.mobility.api.domain.office.dto.request.CreateDispatchReq;
 import com.mobility.api.domain.office.dto.request.DispatchSearchDto;
 import com.mobility.api.domain.office.dto.request.UpdateDispatchReq;
@@ -13,6 +14,7 @@ import com.mobility.api.global.exception.GlobalException;
 import com.mobility.api.global.response.ResultCode;
 import jakarta.persistence.criteria.Predicate;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
@@ -24,9 +26,11 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class OfficeService {
 
     private final DispatchRepository dispatchRepository;
+    private final AutoDispatchService autoDispatchService;
 
     public Page<GetAllDispatchRes> findAllDispatch(DispatchSearchDto searchDto, Pageable pageable) {
 
@@ -62,8 +66,17 @@ public class OfficeService {
         return dispatchPage.map(dispatch -> new GetAllDispatchRes(dispatch)); // DTO 변환
     }
 
+    @Transactional
     public void saveDispatch(CreateDispatchReq createDispatchReq) {
-        dispatchRepository.save(createDispatchReq.toEntity());
+        // 1. 배차 저장
+        Dispatch savedDispatch = dispatchRepository.save(createDispatchReq.toEntity());
+
+        log.info("[Office] 배차 등록 완료 - dispatchId: {}", savedDispatch.getId());
+
+        // 2. 자동 배차 알림 시작 (비동기)
+        autoDispatchService.startSequentialNotification(savedDispatch.getId());
+
+        log.info("[Office] 자동 배차 알림 트리거 완료 - dispatchId: {}", savedDispatch.getId());
     }
 
     @Transactional

--- a/src/main/java/com/mobility/api/domain/transporter/repository/TransporterRepository.java
+++ b/src/main/java/com/mobility/api/domain/transporter/repository/TransporterRepository.java
@@ -15,8 +15,8 @@ public interface TransporterRepository extends JpaRepository<Transporter, Long> 
      * 특정 좌표(lat, lon) 기준, 반경(radiusMeters) 내의 기사를 거리순 조회
      */
     @Query(value = """
-        SELECT t.transporter_id as id, 
-               t.name, 
+        SELECT t.transporter_id as id,
+               t.name,
                t.phone,
                ST_DistanceSphere(t.current_location, ST_SetSRID(ST_MakePoint(:lon, :lat), 4326)) as distanceInMeters
         FROM transporters t
@@ -29,6 +29,32 @@ public interface TransporterRepository extends JpaRepository<Transporter, Long> 
             @Param("lat") double lat,
             @Param("lon") double lon,
             @Param("radiusMeters") double radiusMeters
+    );
+
+    /**
+     * 자동 배차용 적격 기사 조회
+     * - 50km 반경 내 기사
+     * - is_auto_dispatch = true (자동 배차 수신 동의한 기사만)
+     * - 거리순 정렬
+     * - 최대 10명
+     */
+    @Query(value = """
+        SELECT t.transporter_id as id,
+               t.name,
+               t.phone,
+               ST_DistanceSphere(t.current_location, ST_SetSRID(ST_MakePoint(:lon, :lat), 4326)) as distanceInMeters
+        FROM transporters t
+        WHERE t.current_location IS NOT NULL
+          AND t.is_auto_dispatch = true
+          AND ST_DWithin(t.current_location::geography,
+                         ST_SetSRID(ST_MakePoint(:lon, :lat), 4326)::geography,
+                         50000)
+        ORDER BY distanceInMeters ASC
+        LIMIT 10
+        """, nativeQuery = true)
+    List<TransporterDistanceProjection> findEligibleDriversForAutoDispatch(
+            @Param("lat") double lat,
+            @Param("lon") double lon
     );
 
 }

--- a/src/main/java/com/mobility/api/global/config/AsyncConfig.java
+++ b/src/main/java/com/mobility/api/global/config/AsyncConfig.java
@@ -1,0 +1,46 @@
+package com.mobility.api.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
+
+/**
+ * 비동기 처리 설정
+ * - 자동 배차 알림 시스템에서 순차 알림 전송을 비동기로 처리
+ */
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    /**
+     * 자동 배차용 ThreadPool Executor
+     * - 배차 등록 시 비동기로 순차 알림 전송
+     * - 여러 배차가 동시에 등록되어도 독립적으로 처리
+     */
+    @Bean(name = "autoDispatchExecutor")
+    public Executor autoDispatchExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(5);  // 기본 스레드 수
+        executor.setMaxPoolSize(10);  // 최대 스레드 수
+        executor.setQueueCapacity(100);  // 대기 큐 크기
+        executor.setThreadNamePrefix("auto-dispatch-");  // 스레드 이름 prefix
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());  // 큐가 가득 찼을 때 호출자 스레드에서 실행
+        executor.initialize();
+        return executor;
+    }
+
+    /**
+     * 타임아웃 처리용 ScheduledExecutorService
+     * - 각 기사별 5초 타임아웃 스케줄링
+     */
+    @Bean(name = "dispatchTimeoutScheduler")
+    public ScheduledExecutorService dispatchTimeoutScheduler() {
+        return Executors.newScheduledThreadPool(10);
+    }
+}

--- a/src/main/java/com/mobility/api/global/config/SecurityConfig.java
+++ b/src/main/java/com/mobility/api/global/config/SecurityConfig.java
@@ -18,6 +18,13 @@ public class SecurityConfig {
             "/v3/api-docs/**"   // API 설계도(JSON)
     };
 
+    private static final String[] WEBSOCKET_URLS = {
+            "/ws/**",      // WebSocket handshake 엔드포인트
+            "/app/**",     // STOMP 발행 경로 (기사 → 서버)
+            "/queue/**",   // STOMP 구독 경로 (서버 → 기사, 개인)
+            "/topic/**"    // STOMP 구독 경로 (서버 → 전체, 브로드캐스트)
+    };
+
     /**
      * 'dev' 또는 'local' 프로필일 때 활성화되는 보안 설정
      * 프로필이 지정되지 않은 경우에도 기본으로 사용
@@ -44,6 +51,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(authz -> authz
                         .requestMatchers("/api/**").permitAll()
                         .requestMatchers(SWAGGER_URLS).permitAll()
+                        .requestMatchers(WEBSOCKET_URLS).permitAll()  // WebSocket 경로 허용
                         .anyRequest().authenticated() // 그 외 모든 요청은 인증 필요 (사실상 거의 없음)
                 );
         return http.build();

--- a/src/main/java/com/mobility/api/global/config/WebSocketConfig.java
+++ b/src/main/java/com/mobility/api/global/config/WebSocketConfig.java
@@ -1,0 +1,39 @@
+package com.mobility.api.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    /**
+     * 메시지 브로커 설정
+     * - /queue: 1:1 개인 메시지 (특정 기사에게 배차 알림)
+     * - /topic: 1:N 브로드캐스트 메시지 (선택사항)
+     * - /app: 클라이언트가 서버로 메시지를 보낼 때 사용하는 prefix
+     */
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        // 구독 경로 prefix (/queue, /topic)
+        registry.enableSimpleBroker("/queue", "/topic");
+
+        // 클라이언트가 메시지를 보낼 때 사용하는 prefix
+        registry.setApplicationDestinationPrefixes("/app");
+    }
+
+    /**
+     * WebSocket 엔드포인트 등록
+     * - /ws: WebSocket handshake 엔드포인트
+     * - SockJS fallback 지원 (WebSocket을 지원하지 않는 브라우저 대응)
+     */
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws")
+                .setAllowedOriginPatterns("*")  // CORS 설정 (개발 환경용)
+                .withSockJS();  // SockJS fallback 지원
+    }
+}

--- a/src/main/java/com/mobility/api/global/response/ResultCode.java
+++ b/src/main/java/com/mobility/api/global/response/ResultCode.java
@@ -40,6 +40,14 @@ public enum ResultCode {
      * 4000번대 (사무실 관련)
      */
 
+    /**
+     * 5000번대 (배차 제안 관련)
+     */
+    OFFER_NOT_FOUND(HttpStatus.NOT_FOUND, 5001, "배차 제안을 찾을 수 없습니다."),
+    OFFER_ALREADY_RESPONDED(HttpStatus.CONFLICT, 5002, "이미 응답한 배차 제안입니다."),
+    OFFER_EXPIRED(HttpStatus.GONE, 5003, "만료된 배차 제안입니다."),
+    DISPATCH_ALREADY_ASSIGNED(HttpStatus.CONFLICT, 5006, "이미 다른 기사에게 할당된 배차입니다."),
+
     FIXME_FAIL(HttpStatus.NOT_FOUND, 9999, "임시 취소 응답 (수정 필요)"),
 
     /**


### PR DESCRIPTION
## 관련 이슈
#40 

## 📌 작업 개요
- 배차 등록 시 WebSocket을 통해 거리순으로 기사에게 순차적으로 알림을 전송하는 자동 배차 시스템을 구현

### 1. WebSocket 기반 실시간 알림 시스템

- **프로토콜**: STOMP over WebSocket
- **엔드포인트**: `ws://localhost:8080/mobility/ws`
- **양방향 통신**:
    - 서버 → 기사: `/queue/{transporterId}/dispatch` (배차 알림)
    - 기사 → 서버: `/app/dispatch/accept`, `/app/dispatch/reject` (수락/거절)

### 2. 자동 배차 로직

- **적격 기사 조회**: `isAutoDispatch = true`인 기사 중 거리순 최대 10명
- **순차 알림 전송**:
    - 가장 가까운 기사부터 순차적으로 알림
    - 각 기사당 5초 타임아웃
    - 수락 시 배차 할당 후 종료
    - 거절/타임아웃 시 다음 기사에게 전송
- **전원 거절/미응답**: 배차는 OPEN 상태 유지 (수동 배차 대기)

### 3. 동시성 제어

- **비관적 락**: 여러 기사가 동시 수락 시도 시 하나만 성공
- **트랜잭션 격리**: Offer와 Dispatch 각각 락 획득 후 상태 검증

### 4. 비동기 처리

- **@Async**: 자동 배차 프로세스는 독립 스레드에서 실행
- **ThreadPool**: 최대 10개 배차 동시 처리 가능
- **타임아웃**: CompletableFuture + ScheduledExecutorService

## ✨ 기타 참고 사항
- dispatch_offer 테이블 생성

## ✅ 체크리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] `application.yml` 파일을 수정했다면, Notion에 업로드, github security 수정 및 공유했어요.
- [x] 로컬 서버에서 정상 동작을 확인했어요. (main, test)
- [x] 불필요한 코드는 삭제했어요.