### PR TITLE
[#47] feat: 기사 회원가입 및 로그인 구현

### DIFF
--- a/src/main/java/com/mobility/api/domain/auth/controller/AuthOfficeV1Controller.java
+++ b/src/main/java/com/mobility/api/domain/auth/controller/AuthOfficeV1Controller.java
@@ -2,18 +2,12 @@ package com.mobility.api.domain.auth.controller;
 
 import com.mobility.api.domain.auth.dto.response.TokenDto;
 import com.mobility.api.domain.auth.service.AuthService;
-import com.mobility.api.domain.office.dto.request.DispatchSearchDto;
-import com.mobility.api.domain.office.dto.request.OfficeLoginReq;
-import com.mobility.api.domain.office.dto.request.OfficeSignupReq;
-import com.mobility.api.domain.office.dto.response.GetAllDispatchRes;
-import com.mobility.api.global.annotation.SwaggerPageable;
+import com.mobility.api.domain.auth.dto.request.OfficeLoginReq;
+import com.mobility.api.domain.auth.dto.request.OfficeSignupReq;
 import com.mobility.api.global.response.CommonResponse;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "사무실 인증 관련 요청(/api/v1/auth/office/...)")

--- a/src/main/java/com/mobility/api/domain/auth/controller/AuthTransporterV1Controller.java
+++ b/src/main/java/com/mobility/api/domain/auth/controller/AuthTransporterV1Controller.java
@@ -1,0 +1,51 @@
+package com.mobility.api.domain.auth.controller;
+
+import com.mobility.api.domain.auth.dto.request.OfficeLoginReq;
+import com.mobility.api.domain.auth.dto.request.TransporterLoginReq;
+import com.mobility.api.domain.auth.dto.request.TransporterSignupReq;
+import com.mobility.api.domain.auth.dto.response.TokenDto;
+import com.mobility.api.domain.auth.service.AuthService;
+import com.mobility.api.domain.auth.dto.request.OfficeSignupReq;
+import com.mobility.api.global.response.CommonResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "기사 인증 관련 요청(/api/v1/auth/transporter/...)")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/auth/transporter")
+public class AuthTransporterV1Controller {
+
+    private final AuthService authService;
+
+    @Operation(summary = "기사 회원가입")
+    @PostMapping("/signup")
+    public CommonResponse<String> signupOffice(
+            @RequestBody TransporterSignupReq req
+    ) {
+        authService.signupTransporter(req);
+        return CommonResponse.success(null);
+    }
+
+    /**
+     * <pre>
+     * 기사 - 로그인
+     * </pre>
+     */
+    @Operation(summary = "기사 로그인 요청", description = "전화번호를 입력받아 Access Token을 발급합니다.")
+    @PostMapping("/login") // RequestMapping(method=POST)와 같습니다.
+    public CommonResponse<TokenDto> login(@RequestBody TransporterLoginReq req) {
+
+        // 1. 서비스 호출 (로그인 로직 수행)
+        TokenDto tokenDto = authService.transporterLogin(req);
+
+        // 2. 결과 반환
+        return CommonResponse.success(tokenDto);
+    }
+
+}

--- a/src/main/java/com/mobility/api/domain/auth/dto/request/OfficeLoginReq.java
+++ b/src/main/java/com/mobility/api/domain/auth/dto/request/OfficeLoginReq.java
@@ -1,4 +1,4 @@
-package com.mobility.api.domain.office.dto.request;
+package com.mobility.api.domain.auth.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 

--- a/src/main/java/com/mobility/api/domain/auth/dto/request/OfficeSignupReq.java
+++ b/src/main/java/com/mobility/api/domain/auth/dto/request/OfficeSignupReq.java
@@ -1,4 +1,4 @@
-package com.mobility.api.domain.office.dto.request;
+package com.mobility.api.domain.auth.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 

--- a/src/main/java/com/mobility/api/domain/auth/dto/request/TransporterLoginReq.java
+++ b/src/main/java/com/mobility/api/domain/auth/dto/request/TransporterLoginReq.java
@@ -1,0 +1,5 @@
+package com.mobility.api.domain.auth.dto.request;
+
+public record TransporterLoginReq(
+        String phone
+) {}

--- a/src/main/java/com/mobility/api/domain/auth/dto/request/TransporterSignupReq.java
+++ b/src/main/java/com/mobility/api/domain/auth/dto/request/TransporterSignupReq.java
@@ -1,0 +1,7 @@
+package com.mobility.api.domain.auth.dto.request;
+
+public record TransporterSignupReq(
+        String name,
+        String phone,
+        Boolean isAutoDispatch
+) {}

--- a/src/main/java/com/mobility/api/domain/auth/service/AuthService.java
+++ b/src/main/java/com/mobility/api/domain/auth/service/AuthService.java
@@ -1,13 +1,17 @@
 package com.mobility.api.domain.auth.service;
 
+import com.mobility.api.domain.auth.dto.request.TransporterLoginReq;
+import com.mobility.api.domain.auth.dto.request.TransporterSignupReq;
 import com.mobility.api.domain.auth.dto.response.TokenDto;
-import com.mobility.api.domain.office.dto.request.OfficeLoginReq;
-import com.mobility.api.domain.office.dto.request.OfficeSignupReq;
+import com.mobility.api.domain.auth.dto.request.OfficeLoginReq;
+import com.mobility.api.domain.auth.dto.request.OfficeSignupReq;
 import com.mobility.api.domain.office.entity.Manager;
 import com.mobility.api.domain.office.entity.Office;
 import com.mobility.api.domain.office.enums.ManagerRole;
 import com.mobility.api.domain.office.repository.ManagerRepository;
 import com.mobility.api.domain.office.repository.OfficeRepository;
+import com.mobility.api.domain.transporter.entity.Transporter;
+import com.mobility.api.domain.transporter.repository.TransporterRepository;
 import com.mobility.api.global.exception.GlobalException;
 import com.mobility.api.global.jwt.JwtProvider;
 import com.mobility.api.global.response.ResultCode;
@@ -22,6 +26,7 @@ public class AuthService {
 
     private final ManagerRepository managerRepository;
     private final OfficeRepository officeRepository;
+    private final TransporterRepository transporterRepository;
 
     private final JwtProvider jwtProvider;           // 토큰 발급기
     private final PasswordEncoder passwordEncoder;   // 비밀번호 검사기
@@ -82,6 +87,45 @@ public class AuthService {
         // Subject: loginId (나중에 이걸로 DB 조회함)
         // Role: "ROLE_OFFICE" (일단 고정, 필요하면 manager.getRole().name() 사용)
         String accessToken = jwtProvider.createToken(manager.getLoginId(), "ROLE_OFFICE");
+
+        return new TokenDto(accessToken, "Bearer");
+    }
+
+    /**
+     * [기사] 회원가입
+     */
+    @Transactional
+    public void signupTransporter(TransporterSignupReq req) {
+        // 1. 전화번호 중복 검사
+        if (transporterRepository.existsByPhone(req.phone())) {
+            throw new GlobalException(ResultCode.FIXME_FAIL); // 이미 가입된 번호
+        }
+
+        // 2. 기사 정보 생성 및 저장
+        Transporter transporter = Transporter.builder()
+                .name(req.name())
+                .phone(req.phone())
+                .isAutoDispatch(req.isAutoDispatch())
+                .build();
+
+        transporterRepository.save(transporter);
+    }
+
+    /**
+     * [기사] 로그인 (전화번호만 일치하면 통과)
+     */
+    @Transactional
+    public TokenDto transporterLogin(TransporterLoginReq req) {
+        // 1. 전화번호로 기사 찾기
+        Transporter transporter = transporterRepository.findByPhone(req.phone())
+                .orElseThrow(() -> new GlobalException(ResultCode.NOT_FOUND_USER)); // 가입되지 않은 기사
+
+        // 2. 비밀번호 검증 없음 (요구사항 반영: 전화번호만 맞으면 바로 로그인 처리)
+
+        // 3. 토큰 생성
+        // Subject: phone (기사는 ID 대신 전화번호를 식별자로 씀)
+        // Role: "ROLE_TRANSPORTER" (권한 분리)
+        String accessToken = jwtProvider.createToken(transporter.getPhone(), "ROLE_TRANSPORTER");
 
         return new TokenDto(accessToken, "Bearer");
     }

--- a/src/main/java/com/mobility/api/domain/transporter/repository/TransporterRepository.java
+++ b/src/main/java/com/mobility/api/domain/transporter/repository/TransporterRepository.java
@@ -58,6 +58,10 @@ public interface TransporterRepository extends JpaRepository<Transporter, Long> 
             @Param("lon") double lon
     );
 
+    // 전화번호 중복 가입 체크용
+    boolean existsByPhone(String phoneNumber);
+
+    // 로그인 시 기사 조회용 (기사 id는 전화번호이므로 username을 받아서 phone을 조회함)
     Optional<Transporter> findByPhone(String username);
 
 }


### PR DESCRIPTION
## 관련 이슈
#47 

## 📌 작업 개요
- 기사 회원가입 및 로그인 구현

## ✨ 기타 참고 사항
- 

## ✅ 체크리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] `application.yml` 파일을 수정했다면, Notion에 업로드, github security 수정 및 공유했어요.
- [x] 로컬 서버에서 정상 동작을 확인했어요. (main, test)
- [x] 불필요한 코드는 삭제했어요.