### PR TITLE
[#50] feat: 사무실 - 기사 상태 변경 api 추가

### DIFF
--- a/src/main/java/com/mobility/api/domain/office/controller/OfficeV1Controller.java
+++ b/src/main/java/com/mobility/api/domain/office/controller/OfficeV1Controller.java
@@ -9,6 +9,7 @@ import com.mobility.api.domain.office.dto.response.GetAllDispatchRes;
 import com.mobility.api.domain.office.dto.response.GetDispatchDetailRes;
 import com.mobility.api.domain.office.service.OfficeService;
 import com.mobility.api.domain.transporter.dto.request.TransporterCreateReq;
+import com.mobility.api.domain.transporter.dto.request.TransporterStatusUpdateReq;
 import com.mobility.api.domain.transporter.dto.response.TransporterRes;
 import com.mobility.api.global.annotation.SwaggerPageable;
 import com.mobility.api.global.response.CommonResponse;
@@ -145,6 +146,15 @@ public class OfficeV1Controller {
         return CommonResponse.success("프론트 개발 후 작업 예정입니다.");
     }
 
+    /**
+     * <pre>
+     *     기사 등록
+     * </pre>
+     * @param req
+     * @param user
+     * @return
+     */
+    @Operation(summary = "기사 등록", description = "")
     @RequestMapping(path = "/transporter", method = RequestMethod.POST)
     public CommonResponse<String> createTransporter(
             @RequestBody TransporterCreateReq req,
@@ -157,6 +167,14 @@ public class OfficeV1Controller {
         return CommonResponse.success("기사 등록 성공");
     }
 
+    /**
+     * <pre>
+     *     기사 리스트 조회
+     * </pre>
+     * @param user
+     * @return
+     */
+    @Operation(summary = "기사 리스트 조회", description = "")
     @RequestMapping(path = "/transporter", method = RequestMethod.GET)
     public CommonResponse<List<TransporterRes>> getMyTransporters(
             @AuthenticationPrincipal PrincipalDetails user
@@ -166,5 +184,32 @@ public class OfficeV1Controller {
 
         return CommonResponse.success(result);
     }
+
+    /**
+     * <pre>
+     *     기사 상태 변경
+     * </pre>
+     * @param user
+     * @return
+     */
+    @Operation(summary = "기사 상태 변경", description = "")
+    @RequestMapping(path = "/transporter/{transporterId}/status", method = RequestMethod.PATCH)
+    public CommonResponse<Integer> changeTransporterStatus(
+            @AuthenticationPrincipal PrincipalDetails user,
+            @PathVariable Long transporterId,
+            @RequestBody TransporterStatusUpdateReq req
+    ) {
+
+        officeService.changeTransporterStatus(
+                transporterId,
+                req.status(),
+                user.getManager()
+        );
+
+
+        return CommonResponse.success(0);
+    }
+
+
 
 }

--- a/src/main/java/com/mobility/api/domain/office/service/OfficeService.java
+++ b/src/main/java/com/mobility/api/domain/office/service/OfficeService.java
@@ -12,6 +12,7 @@ import com.mobility.api.domain.office.dto.response.GetAllDispatchRes;
 import com.mobility.api.domain.office.dto.response.GetDispatchDetailRes;
 import com.mobility.api.domain.office.entity.Manager;
 import com.mobility.api.domain.office.entity.Office;
+import com.mobility.api.domain.transporter.TransporterStatus;
 import com.mobility.api.domain.transporter.dto.request.TransporterCreateReq;
 import com.mobility.api.domain.transporter.dto.response.TransporterRes;
 import com.mobility.api.domain.transporter.entity.Transporter;
@@ -224,6 +225,33 @@ public class OfficeService {
         return transporters.stream()
                 .map(TransporterRes::from)
                 .toList();
+    }
+
+    @Transactional
+    public void changeTransporterStatus(Long transporterId, TransporterStatus status, Manager manager) {
+
+        // 1. 기사(Transporter) 조회
+        Transporter transporter = transporterRepository.findById(transporterId)
+                .orElseThrow(() -> new GlobalException(ResultCode.NOT_FOUND_TRANSPORTER)); // 에러코드 필요
+
+        // 2. [권한 검증] 사장님네 사무실 기사가 맞는지 확인 ⭐️
+        // 사장님의 사무실과 기사의 사무실 ID가 다르면 에러!
+        Office managerOffice = manager.getOffice();
+        Office transporterOffice = transporter.getOffice();
+
+        // (Null 체크: 혹시 모를 데이터 무결성 문제 방지)
+        if (managerOffice == null || transporterOffice == null) {
+            throw new GlobalException(ResultCode.NOT_FOUND_OFFICE);
+        }
+
+        // ID 비교
+        if (!managerOffice.getId().equals(transporterOffice.getId())) {
+            throw new GlobalException(ResultCode.UNAUTHORIZED_ACCESS);
+        }
+
+        // 3. 상태 변경 (Dirty Checking)
+        transporter.changeStatus(status);
+
     }
 
 }

--- a/src/main/java/com/mobility/api/domain/transporter/TransporterStatus.java
+++ b/src/main/java/com/mobility/api/domain/transporter/TransporterStatus.java
@@ -1,0 +1,8 @@
+package com.mobility.api.domain.transporter;
+
+public enum TransporterStatus {
+    PENDING,   // 승인 대기 (심사 중)
+    ACTIVE,    // 승인 완료 (활동 중)
+    INACTIVE,  // 비활성화 (휴면, 잠금 등)
+    REJECTED   // 승인 거절
+}

--- a/src/main/java/com/mobility/api/domain/transporter/dto/request/TransporterStatusUpdateReq.java
+++ b/src/main/java/com/mobility/api/domain/transporter/dto/request/TransporterStatusUpdateReq.java
@@ -1,0 +1,7 @@
+package com.mobility.api.domain.transporter.dto.request;
+
+import com.mobility.api.domain.transporter.TransporterStatus;
+
+public record TransporterStatusUpdateReq(
+        TransporterStatus status // 변경할 상태 (ACTIVE, REJECTED 등)
+) {}

--- a/src/main/java/com/mobility/api/domain/transporter/entity/Transporter.java
+++ b/src/main/java/com/mobility/api/domain/transporter/entity/Transporter.java
@@ -2,6 +2,7 @@ package com.mobility.api.domain.transporter.entity;
 
 import com.mobility.api.domain.office.entity.Office;
 import com.mobility.api.global.entity.BaseEntity;
+import com.mobility.api.domain.transporter.TransporterStatus;
 import jakarta.persistence.*;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
@@ -36,7 +37,16 @@ public class Transporter extends BaseEntity {
     @Column(name = "is_auto_dispatch")
     private boolean isAutoDispatch;
 
+    // 상태 필드 (기본값: PENDING)
+    @Enumerated(EnumType.STRING)
+    private TransporterStatus status = TransporterStatus.PENDING;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "office_id")    // DB 컬럼명: office_id
     private Office office;
+
+    // 상태 변경 편의 메서드 (Dirty Checking용)
+    public void changeStatus(TransporterStatus newStatus) {
+        this.status = newStatus;
+    }
 }

--- a/src/main/java/com/mobility/api/global/response/ResultCode.java
+++ b/src/main/java/com/mobility/api/global/response/ResultCode.java
@@ -35,10 +35,13 @@ public enum ResultCode {
      * 3000번대 (기사 관련)
      */
     TRANSPORTER_LOCATION_SAVE_SUCCESS(HttpStatus.OK, 3001, "기사 위도 경도 정보가 저장되었습니다"),
+    NOT_FOUND_TRANSPORTER(HttpStatus.NOT_FOUND, 3002, "기사 정보를 찾을 수 없습니다."),
+    UNAUTHORIZED_ACCESS(HttpStatus.NOT_FOUND, 3003, "해당 기사 수정 권한이 없습니다."),
 
     /**
      * 4000번대 (사무실 관련)
      */
+    NOT_FOUND_OFFICE(HttpStatus.NOT_FOUND, 4001, "사무실 정보를 찾을 수 없습니다."),
 
     /**
      * 5000번대 (배차 제안 관련)

--- a/src/main/resources/application-docker.yml
+++ b/src/main/resources/application-docker.yml
@@ -5,6 +5,10 @@ server:
 spring:
   # (DB 접속 정보는 docker-compose.yml에서 주입되므로 여기엔 불필요)
 
+  jackson:
+    mapper:
+      accept-case-insensitive-enums: true
+
   jpa:
     hibernate:
       # (주의!) EC2 운영 환경에서는 'validate' 또는 'none'을 권장


### PR DESCRIPTION
## 관련 이슈
#50 

## 📌 작업 개요
- 기사 상태 변경 api 추가

## ✨ 기타 참고 사항
- 

## ✅ 체크리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] `application.yml` 파일을 수정했다면, Notion에 업로드, github security 수정 및 공유했어요.
- [x] 로컬 서버에서 정상 동작을 확인했어요. (main, test)
- [x] 불필요한 코드는 삭제했어요.