### PR TITLE
[#55] fix: PostgreSQL 파라미터 타입 추론 오류 수정

### DIFF
--- a/src/main/java/com/mobility/api/domain/dispatch/controller/DispatchV1Controller.java
+++ b/src/main/java/com/mobility/api/domain/dispatch/controller/DispatchV1Controller.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-@Tag(name = "Dispatch Matching", description = "배차 관련 API")
+@Tag(name = "배차 관련 API (/api/v1/dispatch)")
 @RestController
 @RequestMapping("/api/v1/dispatch")
 @RequiredArgsConstructor

--- a/src/main/java/com/mobility/api/domain/dispatch/repository/DispatchRepository.java
+++ b/src/main/java/com/mobility/api/domain/dispatch/repository/DispatchRepository.java
@@ -44,7 +44,7 @@ public interface DispatchRepository extends JpaRepository<Dispatch, Long>,
                d.toll_type as tollType
         FROM dispatch d
         WHERE d.active = true
-          AND (:statuses IS NULL OR d.status IN (:statuses))
+          AND (CAST(:statuses AS text[]) IS NULL OR d.status = ANY(CAST(:statuses AS text[])))
         ORDER BY distanceInMeters ASC
         """, nativeQuery = true)
     List<DispatchDistanceProjection> findDispatchesByDistance(


### PR DESCRIPTION
  ## 관련 이슈
- #55

## 📌 작업 개요
  <!-- 어떤 기능/버그를 작업했는지 간단히 설명해주세요 -->
  - `/api/v1/transporter/dispatch-list` API에서 status 파라미터 미입력 시 발생하는 PostgreSQL 타입 추론 오류 수정
  - `DispatchRepository.findDispatchesByDistance()` Native Query 개선

### 문제점
  - status 파라미터가 null일 때 `ERROR: could not determine data type of parameter $3` 오류 발생
  - PostgreSQL이 `IN (:statuses)` 절에서 null 파라미터의 타입을 추론하지 못함

### 해결 방법
  - Native Query의 `IN` 절을 `ANY` 연산자로 변경
  - 명시적으로 `CAST(:statuses AS text[])` 타입 캐스팅 추가
  - 변경 전: `(:statuses IS NULL OR d.status IN (:statuses))`
  - 변경 후: `(CAST(:statuses AS text[]) IS NULL OR d.status = ANY(CAST(:statuses AS text[])))`

## ✨ 기타 참고 사항
  <!-- 리뷰어가 참고해야 할 사항이나, 보완 예정인 내용이 있다면 작성해주세요 -->
  - PostgreSQL Native Query 사용 시 null 파라미터에 대한 명시적 타입 캐스팅 필요
  - 동일한 패턴이 다른 Repository에도 있는지 확인 필요

## ✅ 체크리스트
  - [x] PR 템플릿에 맞추어 작성했어요.
  - [x] PR에 적절한 라벨을 선택했어요.
  - [x] 변경 내용에 대한 테스트를 진행했어요.
  - [x] `application.yml` 파일을 수정했다면, Notion에 업로드, github security 수정 및 공유했어요.
  - [x] 로컬 서버에서 정상 동작을 확인했어요. (main, test)
  - [x] 불필요한 코드는 삭제했어요.

## 테스트 시나리오:
### 1. status 파라미터 없이 요청 (전체 조회)
  GET /api/v1/transporter/dispatch-list

### 2. status 파라미터 1개
  GET /api/v1/transporter/dispatch-list?status=OPEN

### 3. status 파라미터 복수 개
  GET /api/v1/transporter/dispatch-list?status=OPEN&status=HOLD
