### PR TITLE
[#57] feature: 실시간 피드 api 구현

### DIFF
--- a/src/main/java/com/mobility/api/domain/dispatch/repository/DispatchRepository.java
+++ b/src/main/java/com/mobility/api/domain/dispatch/repository/DispatchRepository.java
@@ -4,6 +4,8 @@ import com.mobility.api.domain.dispatch.dto.DispatchDistanceProjection;
 import com.mobility.api.domain.dispatch.entity.Dispatch;
 import jakarta.persistence.LockModeType;
 import jakarta.persistence.QueryHint;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.*;
 import org.springframework.data.repository.query.Param;
 
@@ -64,4 +66,12 @@ public interface DispatchRepository extends JpaRepository<Dispatch, Long>,
      */
     @Query("SELECT d.status, COUNT(d) FROM Dispatch d WHERE d.officeId = :officeId GROUP BY d.status")
     List<Object[]> countByStatusAndOfficeId(@Param("officeId") Long officeId);
+
+    /**
+     * 배차 목록 조회 (Transporter와 Fetch Join으로 N+1 문제 해결)
+     * @param pageable 페이징 및 정렬 정보
+     * @return 배차 목록 (Transporter 포함)
+     */
+    @Query("SELECT d FROM Dispatch d LEFT JOIN FETCH d.transporter")
+    Page<Dispatch> findAllWithTransporter(Pageable pageable);
 }

--- a/src/main/java/com/mobility/api/domain/office/controller/OfficeV1Controller.java
+++ b/src/main/java/com/mobility/api/domain/office/controller/OfficeV1Controller.java
@@ -4,6 +4,7 @@ import com.mobility.api.domain.dispatch.entity.Dispatch;
 import com.mobility.api.domain.office.dto.request.CreateDispatchReq;
 import com.mobility.api.domain.office.dto.request.DispatchSearchDto;
 import com.mobility.api.domain.office.dto.request.UpdateDispatchReq;
+import com.mobility.api.domain.office.dto.response.DispatchFeedRes;
 import com.mobility.api.domain.office.dto.response.DispatchSummaryRes;
 import com.mobility.api.domain.office.dto.response.GetAllDispatchRes;
 import com.mobility.api.domain.office.dto.response.GetDispatchDetailRes;
@@ -80,6 +81,23 @@ public class OfficeV1Controller {
     @RequestMapping(path = "/dispatch/summary", method = RequestMethod.GET)
     public CommonResponse<DispatchSummaryRes> getDispatchSummary() {
         return CommonResponse.success(officeService.getDispatchSummary());
+    }
+
+    /**
+     * <pre>
+     *     사무실 - 대시보드 실시간 피드 조회
+     * </pre>
+     *
+     * @param limit 조회 개수 (기본: 20)
+     * @return 최근 배차 이벤트 피드 목록
+     */
+    @Operation(summary = "대시보드 실시간 피드 조회", description = "최근 배차 이벤트(open, assigned, completed, canceled) 목록을 조회합니다. HOLD 상태는 제외됩니다.")
+    @RequestMapping(path = "/dispatch/feed", method = RequestMethod.GET)
+    public CommonResponse<List<DispatchFeedRes>> getDispatchFeed(
+            @Parameter(description = "조회 개수", example = "20")
+            @RequestParam(required = false, defaultValue = "20") Integer limit
+    ) {
+        return CommonResponse.success(officeService.getDispatchFeed(limit));
     }
 
     /**
@@ -206,10 +224,7 @@ public class OfficeV1Controller {
                 user.getManager()
         );
 
-
         return CommonResponse.success(0);
     }
-
-
 
 }

--- a/src/main/java/com/mobility/api/domain/office/controller/OfficeV1Controller.java
+++ b/src/main/java/com/mobility/api/domain/office/controller/OfficeV1Controller.java
@@ -91,10 +91,54 @@ public class OfficeV1Controller {
      * @param limit 조회 개수 (기본: 20)
      * @return 최근 배차 이벤트 피드 목록
      */
-    @Operation(summary = "대시보드 실시간 피드 조회", description = "최근 배차 이벤트(open, assigned, completed, canceled) 목록을 조회합니다. HOLD 상태는 제외됩니다.")
+    @Operation(
+            summary = "대시보드 실시간 피드 조회",
+            description = """
+                    최근 배차 이벤트를 시간순으로 조회합니다.
+
+                    **피드 타입:**
+                    - `open`: 배차 등록
+                    - `assigned`: 배차 할당 (기사 배정)
+                    - `completed`: 운송 완료
+                    - `canceled`: 배차 취소
+
+                    **특징:**
+                    - HOLD 상태(자동배차 진행 중)는 제외됩니다.
+                    - 최신순 정렬 (createdAt DESC)
+                    - Transporter 정보 포함 (N+1 최적화 적용)
+
+                    **응답 예시:**
+                    ```json
+                    {
+                      "code": "SUCCESS",
+                      "data": [
+                        {
+                          "id": "feed-01",
+                          "type": "assigned",
+                          "dispatchId": 123,
+                          "dispatchNumber": "2024-0001",
+                          "transporterName": "김철수",
+                          "message": "김철수 기사가 콜 #2024-0001을 배차 받았습니다",
+                          "timestamp": "2024-01-15T10:32:00"
+                        }
+                      ]
+                    }
+                    ```
+                    """
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공"
+            )
+    })
     @RequestMapping(path = "/dispatch/feed", method = RequestMethod.GET)
     public CommonResponse<List<DispatchFeedRes>> getDispatchFeed(
-            @Parameter(description = "조회 개수", example = "20")
+            @Parameter(
+                    description = "조회할 피드 개수 (기본값: 20, 최대 권장: 100)",
+                    example = "20",
+                    required = false
+            )
             @RequestParam(required = false, defaultValue = "20") Integer limit
     ) {
         return CommonResponse.success(officeService.getDispatchFeed(limit));

--- a/src/main/java/com/mobility/api/domain/office/dto/response/DispatchFeedRes.java
+++ b/src/main/java/com/mobility/api/domain/office/dto/response/DispatchFeedRes.java
@@ -1,0 +1,32 @@
+package com.mobility.api.domain.office.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "배차 피드 응답 DTO")
+@Builder
+public record DispatchFeedRes(
+        @Schema(description = "피드 ID", example = "open-123")
+        String id,
+
+        @Schema(description = "피드 타입", example = "assigned", allowableValues = {"open", "assigned", "completed", "canceled"})
+        String type,
+
+        @Schema(description = "배차 ID", example = "123")
+        Long dispatchId,
+
+        @Schema(description = "배차 번호", example = "2024-0001")
+        String dispatchNumber,
+
+        @Schema(description = "기사 이름 (assigned, completed 시에만 존재)", example = "김철수")
+        String transporterName,
+
+        @Schema(description = "피드 메시지", example = "김철수 기사가 콜 #2024-0001을 배차 받았습니다")
+        String message,
+
+        @Schema(description = "이벤트 발생 시간 (BaseEntity.createdAt 또는 이벤트별 타임스탬프)", example = "2024-01-15T10:32:00")
+        LocalDateTime timestamp
+) {
+}

--- a/src/main/java/com/mobility/api/domain/office/dto/response/DispatchFeedRes.java
+++ b/src/main/java/com/mobility/api/domain/office/dto/response/DispatchFeedRes.java
@@ -5,28 +5,75 @@ import lombok.Builder;
 
 import java.time.LocalDateTime;
 
-@Schema(description = "배차 피드 응답 DTO")
+@Schema(description = "대시보드 배차 피드 응답 DTO - 최근 배차 이벤트 정보")
 @Builder
 public record DispatchFeedRes(
-        @Schema(description = "피드 ID", example = "open-123")
+        @Schema(
+                description = "피드 고유 ID (연번 형식: feed-01, feed-02, ...)",
+                example = "feed-01",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
         String id,
 
-        @Schema(description = "피드 타입", example = "assigned", allowableValues = {"open", "assigned", "completed", "canceled"})
+        @Schema(
+                description = """
+                        피드 타입
+                        - open: 배차 등록
+                        - assigned: 배차 할당 (기사 배정)
+                        - completed: 운송 완료
+                        - canceled: 배차 취소
+                        """,
+                example = "assigned",
+                allowableValues = {"open", "assigned", "completed", "canceled"},
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
         String type,
 
-        @Schema(description = "배차 ID", example = "123")
+        @Schema(
+                description = "배차 ID (Dispatch 테이블의 PK)",
+                example = "123",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
         Long dispatchId,
 
-        @Schema(description = "배차 번호", example = "2024-0001")
+        @Schema(
+                description = "배차 번호 (예: 2024-0001) - null일 수 있음",
+                example = "2024-0001",
+                nullable = true
+        )
         String dispatchNumber,
 
-        @Schema(description = "기사 이름 (assigned, completed 시에만 존재)", example = "김철수")
+        @Schema(
+                description = "기사 이름 - assigned, completed 타입일 때만 값이 있고, open, canceled 타입일 때는 null",
+                example = "김철수",
+                nullable = true
+        )
         String transporterName,
 
-        @Schema(description = "피드 메시지", example = "김철수 기사가 콜 #2024-0001을 배차 받았습니다")
+        @Schema(
+                description = """
+                        자동 생성된 피드 메시지
+                        - open: "배차 #{번호}가 등록되었습니다"
+                        - assigned: "{기사명} 기사가 콜 #{번호}을 배차 받았습니다"
+                        - completed: "{기사명} 기사가 콜 #{번호}을 완료했습니다"
+                        - canceled: "배차 #{번호}이 취소되었습니다"
+                        """,
+                example = "김철수 기사가 콜 #2024-0001을 배차 받았습니다",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
         String message,
 
-        @Schema(description = "이벤트 발생 시간 (BaseEntity.createdAt 또는 이벤트별 타임스탬프)", example = "2024-01-15T10:32:00")
+        @Schema(
+                description = """
+                        이벤트 발생 시간 (타입별 타임스탬프)
+                        - open: createdAt (배차 생성 시간)
+                        - assigned: assignedAt (배차 할당 시간)
+                        - completed: completedAt (운송 완료 시간)
+                        - canceled: canceledAt (취소 시간)
+                        """,
+                example = "2024-01-15T10:32:00",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
         LocalDateTime timestamp
 ) {
 }

--- a/src/main/java/com/mobility/api/domain/office/service/OfficeService.java
+++ b/src/main/java/com/mobility/api/domain/office/service/OfficeService.java
@@ -268,10 +268,16 @@ public class OfficeService {
                         org.springframework.data.domain.Sort.by(org.springframework.data.domain.Sort.Direction.DESC, "createdAt"))
         ).getContent();
 
-        // 각 배차를 피드 DTO로 변환
-        return recentDispatches.stream()
-                .filter(dispatch -> dispatch.getStatus() != StatusType.HOLD) // HOLD 상태 제외
-                .map(dispatch -> {
+        // HOLD 상태 제외 후 리스트로 변환
+        List<Dispatch> filteredDispatches = recentDispatches.stream()
+                .filter(dispatch -> dispatch.getStatus() != StatusType.HOLD)
+                .toList();
+
+        // 각 배차를 피드 DTO로 변환 (연번 부여)
+        return java.util.stream.IntStream.range(0, filteredDispatches.size())
+                .mapToObj(index -> {
+                    Dispatch dispatch = filteredDispatches.get(index);
+                    String feedId = String.format("feed-%02d", index + 1); // feed-01, feed-02, ...
                     String type = dispatch.getStatus().name().toLowerCase();
                     String transporterName = (dispatch.getTransporter() != null) ? dispatch.getTransporter().getName() : null;
                     String dispatchNumberDisplay = (dispatch.getDispatchNumber() != null) ? "#" + dispatch.getDispatchNumber() : "#" + dispatch.getId();
@@ -295,7 +301,7 @@ public class OfficeService {
                     };
 
                     return DispatchFeedRes.builder()
-                            .id(type + "-" + dispatch.getId())
+                            .id(feedId)
                             .type(type)
                             .dispatchId(dispatch.getId())
                             .dispatchNumber(dispatch.getDispatchNumber())

--- a/src/main/java/com/mobility/api/domain/office/service/OfficeService.java
+++ b/src/main/java/com/mobility/api/domain/office/service/OfficeService.java
@@ -262,8 +262,8 @@ public class OfficeService {
      */
     @Transactional(readOnly = true)
     public List<DispatchFeedRes> getDispatchFeed(Integer limit) {
-        // 최근 배차 조회 (HOLD 상태 제외, createdAt 기준 내림차순)
-        List<Dispatch> recentDispatches = dispatchRepository.findAll(
+        // 최근 배차 조회 (Transporter와 Fetch Join으로 N+1 문제 해결, createdAt 기준 내림차순)
+        List<Dispatch> recentDispatches = dispatchRepository.findAllWithTransporter(
                 org.springframework.data.domain.PageRequest.of(0, limit,
                         org.springframework.data.domain.Sort.by(org.springframework.data.domain.Sort.Direction.DESC, "createdAt"))
         ).getContent();

--- a/src/main/java/com/mobility/api/domain/office/service/OfficeService.java
+++ b/src/main/java/com/mobility/api/domain/office/service/OfficeService.java
@@ -7,6 +7,7 @@ import com.mobility.api.domain.dispatch.service.AutoDispatchService;
 import com.mobility.api.domain.office.dto.request.CreateDispatchReq;
 import com.mobility.api.domain.office.dto.request.DispatchSearchDto;
 import com.mobility.api.domain.office.dto.request.UpdateDispatchReq;
+import com.mobility.api.domain.office.dto.response.DispatchFeedRes;
 import com.mobility.api.domain.office.dto.response.DispatchSummaryRes;
 import com.mobility.api.domain.office.dto.response.GetAllDispatchRes;
 import com.mobility.api.domain.office.dto.response.GetDispatchDetailRes;
@@ -252,6 +253,58 @@ public class OfficeService {
         // 3. 상태 변경 (Dirty Checking)
         transporter.changeStatus(status);
 
+    }
+
+    /**
+     * 대시보드 실시간 피드 조회
+     * @param limit 조회 개수 (기본: 20)
+     * @return 최근 배차 이벤트 피드 목록
+     */
+    @Transactional(readOnly = true)
+    public List<DispatchFeedRes> getDispatchFeed(Integer limit) {
+        // 최근 배차 조회 (HOLD 상태 제외, createdAt 기준 내림차순)
+        List<Dispatch> recentDispatches = dispatchRepository.findAll(
+                org.springframework.data.domain.PageRequest.of(0, limit,
+                        org.springframework.data.domain.Sort.by(org.springframework.data.domain.Sort.Direction.DESC, "createdAt"))
+        ).getContent();
+
+        // 각 배차를 피드 DTO로 변환
+        return recentDispatches.stream()
+                .filter(dispatch -> dispatch.getStatus() != StatusType.HOLD) // HOLD 상태 제외
+                .map(dispatch -> {
+                    String type = dispatch.getStatus().name().toLowerCase();
+                    String transporterName = (dispatch.getTransporter() != null) ? dispatch.getTransporter().getName() : null;
+                    String dispatchNumberDisplay = (dispatch.getDispatchNumber() != null) ? "#" + dispatch.getDispatchNumber() : "#" + dispatch.getId();
+
+                    // 상태별 타임스탬프 선택
+                    java.time.LocalDateTime timestamp = switch (dispatch.getStatus()) {
+                        case OPEN -> dispatch.getCreatedAt();
+                        case ASSIGNED -> dispatch.getAssignedAt();
+                        case COMPLETED -> dispatch.getCompletedAt();
+                        case CANCELED -> dispatch.getCanceledAt();
+                        default -> dispatch.getCreatedAt();
+                    };
+
+                    // 상태별 메시지 생성
+                    String message = switch (dispatch.getStatus()) {
+                        case OPEN -> "배차 " + dispatchNumberDisplay + "가 등록되었습니다";
+                        case ASSIGNED -> transporterName + " 기사가 콜 " + dispatchNumberDisplay + "을 배차 받았습니다";
+                        case COMPLETED -> transporterName + " 기사가 콜 " + dispatchNumberDisplay + "을 완료했습니다";
+                        case CANCELED -> "배차 " + dispatchNumberDisplay + "이 취소되었습니다";
+                        default -> "배차 " + dispatchNumberDisplay;
+                    };
+
+                    return DispatchFeedRes.builder()
+                            .id(type + "-" + dispatch.getId())
+                            .type(type)
+                            .dispatchId(dispatch.getId())
+                            .dispatchNumber(dispatch.getDispatchNumber())
+                            .transporterName(transporterName)
+                            .message(message)
+                            .timestamp(timestamp)
+                            .build();
+                })
+                .toList();
     }
 
 }


### PR DESCRIPTION
## 관련 이슈
<!-- 이슈 번호가 있다면 여기에 작성 -->
- #57 

## 📌 작업 개요
<!-- 어떤 기능/버그를 작업했는지 간단히 설명해주세요 -->
- 대시보드 실시간 피드 API 추가 (`GET /api/v1/office/dispatch/feed`)
- 배차 이벤트(등록/할당/완료/취소)를 시간순으로 조회하는 API 구현
- Fetch Join을 사용한 N+1 쿼리 문제 해결 (쿼리 수 95% 감소)

### 주요 기능
1. **피드 타입별 이벤트 조회**
   - `open`: 배차 등록
   - `assigned`: 배차 할당 (기사 배정)
   - `completed`: 운송 완료
   - `canceled`: 배차 취소

2. **쿼리 파라미터**
   - `limit`: 조회 개수 (기본값: 20)

3. **응답 정보**
   - 피드 ID (feed-01, feed-02 형식)
   - 배차 정보 (ID, 번호)
   - 기사 정보 (assigned, completed 타입 시)
   - 자동 생성된 메시지
   - 타입별 타임스탬프

### 성능 최적화
- **N+1 문제 해결**: LEFT JOIN FETCH로 Transporter 즉시 로딩
- **쿼리 수**: 21개 → 1개 (95% 감소)

### 구현 상세
```
📁 변경/추가 파일
├── DispatchFeedRes.java (신규)              # 피드 응답 DTO
├── OfficeV1Controller.java                  # GET /dispatch/feed 엔드포인트 추가
├── OfficeService.java                       # getDispatchFeed() 메서드 추가
└── DispatchRepository.java                  # findAllWithTransporter() 추가 (Fetch Join)```

### API 엔드포인트
```
GET /api/v1/office/dispatch/feed?limit=20
```

### 응답 예시
```json
{
  "code": "SUCCESS",
  "data": [
    {
      "id": "feed-01",
      "type": "assigned",
      "dispatchId": 123,
      "dispatchNumber": "2024-0001",
      "transporterName": "김철수",
      "message": "김철수 기사가 콜 #2024-0001을 배차 받았습니다",
      "timestamp": "2024-01-15T10:32:00"
    }
  ]
}
```

## ✨ 기타 참고 사항
<!-- 리뷰어가 참고해야 할 사항이나, 보완 예정인 내용이 있다면 작성해주세요 -->
- **인증/인가 미적용**: 현재 배차 관련 API와 동일하게 인증 없이 구현됨 (향후 추가 가능)
- **HOLD 상태 제외**: 자동배차 진행 중인 배차는 피드에서 제외됨
- **Swagger 문서화 완료**: 모든 필드 및 파라미터에 상세 설명 추가
- **@Transactional(readOnly = true)**: 조회 최적화를 위해 사용 (기존 조회 메서드와 일관성 유지)

### 리뷰 포인트
1. 피드 ID 형식 (`feed-01`, `feed-02`) 적절성
2. Fetch Join 사용으로 인한 페이징 제약사항 없음 확인 (ManyToOne 관계)
3. 메시지 자동 생성 로직의 적절성
4. limit 파라미터 기본값(20) 및 최대값 제한 필요 여부

## ✅ 체크리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] `application.yml` 파일을 수정했다면, Notion에 업로드, github security 수정 및 공유했어요. (해당 없음)
- [x] 로컬 서버에서 정상 동작을 확인했어요. (main, test)
- [x] 불필요한 코드는 삭제했어요.

---

### 커밋 메시지 (참고)
```
feat: 대시보드 실시간 피드 API 추가 및 N+1 문제 해결

- GET /api/v1/office/dispatch/feed 엔드포인트 추가
- DispatchFeedRes DTO 생성 (피드 전용 응답 구조)
- LEFT JOIN FETCH로 N+1 쿼리 문제 해결 (21개 → 1개)
- limit 파라미터 지원 (기본값: 20)
- 피드 타입별 메시지 자동 생성 (open/assigned/completed/canceled)
```