### PR TITLE
[#57] feature: 실시간 피드 api 인증, 필터링, 테스트 코드 추가

### DIFF
--- a/src/main/java/com/mobility/api/domain/office/controller/OfficeV1Controller.java
+++ b/src/main/java/com/mobility/api/domain/office/controller/OfficeV1Controller.java
@@ -139,9 +139,10 @@ public class OfficeV1Controller {
                     example = "20",
                     required = false
             )
-            @RequestParam(required = false, defaultValue = "20") Integer limit
+            @RequestParam(required = false, defaultValue = "20") Integer limit,
+            @AuthenticationPrincipal PrincipalDetails user
     ) {
-        return CommonResponse.success(officeService.getDispatchFeed(limit));
+        return CommonResponse.success(officeService.getDispatchFeed(limit, user.getManager()));
     }
 
     /**

--- a/src/main/java/com/mobility/api/domain/office/controller/OfficeV1Controller.java
+++ b/src/main/java/com/mobility/api/domain/office/controller/OfficeV1Controller.java
@@ -96,16 +96,21 @@ public class OfficeV1Controller {
             description = """
                     최근 배차 이벤트를 시간순으로 조회합니다.
 
-                    **피드 타입:**
-                    - `open`: 배차 등록
-                    - `assigned`: 배차 할당 (기사 배정)
+                    **반환되는 배차 상태 (4가지):**
+                    - `open`: 배차 등록 (대기 중)
+                    - `assigned`: 배차 할당 (기사 배정 완료)
                     - `completed`: 운송 완료
                     - `canceled`: 배차 취소
 
+                    **제외되는 상태:**
+                    - `HOLD`: 자동배차 진행 중 상태는 요구사항에 따라 피드에서 제외됩니다.
+                      (HOLD는 임시 상태로, 최대 50초 이내에 OPEN 또는 ASSIGNED로 전환됨)
+
                     **특징:**
-                    - HOLD 상태(자동배차 진행 중)는 제외됩니다.
+                    - 현재 로그인한 사무실의 배차만 조회됩니다 (officeId 필터링)
                     - 최신순 정렬 (createdAt DESC)
                     - Transporter 정보 포함 (N+1 최적화 적용)
+                    - transporterName은 assigned/completed 타입에만 값이 있고, open/canceled는 null
 
                     **응답 예시:**
                     ```json
@@ -120,6 +125,15 @@ public class OfficeV1Controller {
                           "transporterName": "김철수",
                           "message": "김철수 기사가 콜 #2024-0001을 배차 받았습니다",
                           "timestamp": "2024-01-15T10:32:00"
+                        },
+                        {
+                          "id": "feed-02",
+                          "type": "open",
+                          "dispatchId": 124,
+                          "dispatchNumber": "2024-0002",
+                          "transporterName": null,
+                          "message": "배차 #2024-0002가 등록되었습니다",
+                          "timestamp": "2024-01-15T10:30:00"
                         }
                       ]
                     }

--- a/src/main/java/com/mobility/api/domain/office/service/OfficeService.java
+++ b/src/main/java/com/mobility/api/domain/office/service/OfficeService.java
@@ -258,19 +258,23 @@ public class OfficeService {
     /**
      * 대시보드 실시간 피드 조회
      * @param limit 조회 개수 (기본: 20)
+     * @param manager 현재 로그인한 관리자
      * @return 최근 배차 이벤트 피드 목록
      */
     @Transactional(readOnly = true)
-    public List<DispatchFeedRes> getDispatchFeed(Integer limit) {
+    public List<DispatchFeedRes> getDispatchFeed(Integer limit, Manager manager) {
         // 최근 배차 조회 (Transporter와 Fetch Join으로 N+1 문제 해결, createdAt 기준 내림차순)
         List<Dispatch> recentDispatches = dispatchRepository.findAllWithTransporter(
                 org.springframework.data.domain.PageRequest.of(0, limit,
                         org.springframework.data.domain.Sort.by(org.springframework.data.domain.Sort.Direction.DESC, "createdAt"))
         ).getContent();
 
-        // HOLD 상태 제외 후 리스트로 변환
+        Long officeId = manager.getOffice().getId();
+
+        // HOLD 상태 제외 및 현재 사무실 배차만 필터링
         List<Dispatch> filteredDispatches = recentDispatches.stream()
                 .filter(dispatch -> dispatch.getStatus() != StatusType.HOLD)
+                .filter(dispatch -> dispatch.getOfficeId().equals(officeId))
                 .toList();
 
         // 각 배차를 피드 DTO로 변환 (연번 부여)

--- a/src/test/java/com/mobility/api/domain/office/controller/OfficeV1ControllerTest.java
+++ b/src/test/java/com/mobility/api/domain/office/controller/OfficeV1ControllerTest.java
@@ -1,0 +1,274 @@
+package com.mobility.api.domain.office.controller;
+
+import com.mobility.api.domain.dispatch.enums.StatusType;
+import com.mobility.api.domain.office.dto.response.DispatchFeedRes;
+import com.mobility.api.domain.office.entity.Manager;
+import com.mobility.api.domain.office.entity.Office;
+import com.mobility.api.domain.office.enums.ManagerRole;
+import com.mobility.api.domain.office.repository.ManagerRepository;
+import com.mobility.api.domain.office.service.OfficeService;
+import com.mobility.api.domain.transporter.repository.TransporterRepository;
+import com.mobility.api.global.jwt.JwtProvider;
+import com.mobility.api.global.security.CustomUserDetailsService;
+import com.mobility.api.global.security.PrincipalDetails;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(OfficeV1Controller.class)
+class OfficeV1ControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private OfficeService officeService;
+
+    @MockitoBean
+    private ManagerRepository managerRepository;
+
+    @MockitoBean
+    private TransporterRepository transporterRepository;
+
+    @MockitoBean
+    private JwtProvider jwtProvider;
+
+    @MockitoBean
+    private CustomUserDetailsService customUserDetailsService;
+
+    @MockitoBean
+    private JpaMetamodelMappingContext jpaMetamodelMappingContext;
+
+    private Manager testManager;
+    private Office testOffice;
+    private PrincipalDetails testPrincipalDetails;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        // Mock Office 생성
+        testOffice = Office.builder()
+                .officeName("테스트 사무실")
+                .officeRegistrationNumber("123-45-67890")
+                .officeAddress("서울시 강남구")
+                .officeTelNumber("02-1234-5678")
+                .build();
+
+        // Reflection으로 id 설정
+        java.lang.reflect.Field officeIdField = Office.class.getDeclaredField("id");
+        officeIdField.setAccessible(true);
+        officeIdField.set(testOffice, 1L);
+
+        // Mock Manager 생성
+        testManager = Manager.builder()
+                .loginId("testmanager")
+                .password("encodedPassword")
+                .name("테스트 관리자")
+                .phone("010-1234-5678")
+                .email("test@example.com")
+                .role(ManagerRole.OWNER)
+                .office(testOffice)
+                .build();
+
+        // Reflection으로 id 설정
+        java.lang.reflect.Field managerIdField = Manager.class.getDeclaredField("id");
+        managerIdField.setAccessible(true);
+        managerIdField.set(testManager, 1L);
+
+        // PrincipalDetails 생성
+        testPrincipalDetails = new PrincipalDetails(testManager);
+    }
+
+    @Test
+    @DisplayName("[API] 배차 피드 조회 - 성공 (200 OK)")
+    @WithMockUser
+    void getDispatchFeed_Success() throws Exception {
+        // given
+        Integer limit = 20;
+
+        List<DispatchFeedRes> mockFeedList = List.of(
+                DispatchFeedRes.builder()
+                        .id("feed-01")
+                        .type("assigned")
+                        .dispatchId(101L)
+                        .dispatchNumber("2024-0001")
+                        .transporterName("김철수")
+                        .message("김철수 기사가 콜 #2024-0001을 배차 받았습니다")
+                        .timestamp(LocalDateTime.of(2024, 1, 15, 10, 30, 0))
+                        .build(),
+                DispatchFeedRes.builder()
+                        .id("feed-02")
+                        .type("open")
+                        .dispatchId(102L)
+                        .dispatchNumber("2024-0002")
+                        .transporterName(null)
+                        .message("배차 #2024-0002가 등록되었습니다")
+                        .timestamp(LocalDateTime.of(2024, 1, 15, 10, 25, 0))
+                        .build(),
+                DispatchFeedRes.builder()
+                        .id("feed-03")
+                        .type("completed")
+                        .dispatchId(103L)
+                        .dispatchNumber("2024-0003")
+                        .transporterName("이영희")
+                        .message("이영희 기사가 콜 #2024-0003을 완료했습니다")
+                        .timestamp(LocalDateTime.of(2024, 1, 15, 10, 20, 0))
+                        .build()
+        );
+
+        // Stubbing
+        given(officeService.getDispatchFeed(eq(limit), any(Manager.class)))
+                .willReturn(mockFeedList);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/office/dispatch/feed")
+                        .param("limit", String.valueOf(limit))
+                        .with(user(testPrincipalDetails))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+
+                // CommonResponse 구조 검증
+                .andExpect(jsonPath("$.statusCode").value(0))
+                .andExpect(jsonPath("$.message").value("정상 처리 되었습니다."))
+
+                // 데이터(List) 검증
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data.length()").value(3))
+
+                // 첫 번째 피드 검증 (assigned)
+                .andExpect(jsonPath("$.data[0].id").value("feed-01"))
+                .andExpect(jsonPath("$.data[0].type").value("assigned"))
+                .andExpect(jsonPath("$.data[0].dispatchId").value(101L))
+                .andExpect(jsonPath("$.data[0].dispatchNumber").value("2024-0001"))
+                .andExpect(jsonPath("$.data[0].transporterName").value("김철수"))
+                .andExpect(jsonPath("$.data[0].message").value("김철수 기사가 콜 #2024-0001을 배차 받았습니다"))
+
+                // 두 번째 피드 검증 (open)
+                .andExpect(jsonPath("$.data[1].id").value("feed-02"))
+                .andExpect(jsonPath("$.data[1].type").value("open"))
+                .andExpect(jsonPath("$.data[1].transporterName").doesNotExist())
+
+                // 세 번째 피드 검증 (completed)
+                .andExpect(jsonPath("$.data[2].id").value("feed-03"))
+                .andExpect(jsonPath("$.data[2].type").value("completed"))
+                .andExpect(jsonPath("$.data[2].transporterName").value("이영희"));
+    }
+
+    @Test
+    @DisplayName("[API] 배차 피드 조회 - 기본 limit 값 사용 (limit 미지정 시 20)")
+    @WithMockUser
+    void getDispatchFeed_DefaultLimit() throws Exception {
+        // given
+        List<DispatchFeedRes> mockFeedList = List.of(
+                DispatchFeedRes.builder()
+                        .id("feed-01")
+                        .type("open")
+                        .dispatchId(101L)
+                        .dispatchNumber("2024-0001")
+                        .transporterName(null)
+                        .message("배차 #2024-0001가 등록되었습니다")
+                        .timestamp(LocalDateTime.now())
+                        .build()
+        );
+
+        // limit이 20으로 호출되어야 함
+        given(officeService.getDispatchFeed(eq(20), any(Manager.class)))
+                .willReturn(mockFeedList);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/office/dispatch/feed")
+                        .with(user(testPrincipalDetails))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data.length()").value(1));
+    }
+
+    @Test
+    @DisplayName("[API] 배차 피드 조회 - 빈 결과 (배차가 없는 경우)")
+    @WithMockUser
+    void getDispatchFeed_EmptyResult() throws Exception {
+        // given
+        Integer limit = 20;
+        List<DispatchFeedRes> emptyList = List.of();
+
+        given(officeService.getDispatchFeed(eq(limit), any(Manager.class)))
+                .willReturn(emptyList);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/office/dispatch/feed")
+                        .param("limit", String.valueOf(limit))
+                        .with(user(testPrincipalDetails))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.statusCode").value(0))
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data.length()").value(0));
+    }
+
+    @Test
+    @DisplayName("[API] 배차 피드 조회 - 인증 없이 접근 시 실패 (401 Unauthorized)")
+    void getDispatchFeed_Unauthorized() throws Exception {
+        // given - 인증 정보 없이 요청
+
+        // when & then
+        mockMvc.perform(get("/api/v1/office/dispatch/feed")
+                        .param("limit", "20")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("[API] 배차 피드 조회 - 커스텀 limit 값 사용 (50)")
+    @WithMockUser
+    void getDispatchFeed_CustomLimit() throws Exception {
+        // given
+        Integer customLimit = 50;
+        List<DispatchFeedRes> mockFeedList = List.of(
+                DispatchFeedRes.builder()
+                        .id("feed-01")
+                        .type("canceled")
+                        .dispatchId(101L)
+                        .dispatchNumber("2024-0001")
+                        .transporterName(null)
+                        .message("배차 #2024-0001이 취소되었습니다")
+                        .timestamp(LocalDateTime.now())
+                        .build()
+        );
+
+        given(officeService.getDispatchFeed(eq(customLimit), any(Manager.class)))
+                .willReturn(mockFeedList);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/office/dispatch/feed")
+                        .param("limit", String.valueOf(customLimit))
+                        .with(user(testPrincipalDetails))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.length()").value(1))
+                .andExpect(jsonPath("$.data[0].type").value("canceled"));
+    }
+}

--- a/src/test/java/com/mobility/api/domain/office/service/OfficeServiceTest.java
+++ b/src/test/java/com/mobility/api/domain/office/service/OfficeServiceTest.java
@@ -1,0 +1,326 @@
+package com.mobility.api.domain.office.service;
+
+import com.mobility.api.domain.dispatch.entity.Dispatch;
+import com.mobility.api.domain.dispatch.enums.StatusType;
+import com.mobility.api.domain.dispatch.repository.DispatchRepository;
+import com.mobility.api.domain.office.dto.response.DispatchFeedRes;
+import com.mobility.api.domain.office.entity.Manager;
+import com.mobility.api.domain.office.entity.Office;
+import com.mobility.api.domain.office.enums.ManagerRole;
+import com.mobility.api.domain.transporter.entity.Transporter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class OfficeServiceTest {
+
+    @Mock
+    private DispatchRepository dispatchRepository;
+
+    @InjectMocks
+    private OfficeService officeService;
+
+    private Manager testManager;
+    private Office testOffice;
+    private Office otherOffice;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        // 테스트 사무실 1 (ID: 1)
+        testOffice = Office.builder()
+                .officeName("테스트 사무실")
+                .officeRegistrationNumber("123-45-67890")
+                .officeAddress("서울시 강남구")
+                .officeTelNumber("02-1234-5678")
+                .build();
+
+        // Reflection으로 id 설정
+        java.lang.reflect.Field officeIdField = Office.class.getDeclaredField("id");
+        officeIdField.setAccessible(true);
+        officeIdField.set(testOffice, 1L);
+
+        // 테스트 매니저 (사무실 1 소속)
+        testManager = Manager.builder()
+                .loginId("testmanager")
+                .password("encodedPassword")
+                .name("테스트 관리자")
+                .phone("010-1234-5678")
+                .email("test@example.com")
+                .role(ManagerRole.OWNER)
+                .office(testOffice)
+                .build();
+
+        // Reflection으로 id 설정
+        java.lang.reflect.Field managerIdField = Manager.class.getDeclaredField("id");
+        managerIdField.setAccessible(true);
+        managerIdField.set(testManager, 1L);
+
+        // 다른 사무실 2 (ID: 2)
+        otherOffice = Office.builder()
+                .officeName("다른 사무실")
+                .officeRegistrationNumber("987-65-43210")
+                .officeAddress("서울시 서초구")
+                .officeTelNumber("02-9876-5432")
+                .build();
+
+        // Reflection으로 id 설정
+        officeIdField.set(otherOffice, 2L);
+    }
+
+    @Test
+    @DisplayName("[Service] 배차 피드 조회 - 현재 사무실의 배차만 필터링")
+    void getDispatchFeed_FilterByOfficeId() {
+        // given
+        Integer limit = 20;
+
+        Transporter transporter1 = Transporter.builder()
+                .id(1L)
+                .name("김철수")
+                .phone("010-1111-2222")
+                .build();
+
+        Transporter transporter2 = Transporter.builder()
+                .id(2L)
+                .name("이영희")
+                .phone("010-3333-4444")
+                .build();
+
+        // Repository에서 반환될 배차 목록 (여러 사무실 혼재)
+        List<Dispatch> allDispatches = List.of(
+                // 사무실 1의 배차 (testOffice) - 포함되어야 함
+                Dispatch.builder()
+                        .id(101L)
+                        .officeId(1L)  // testOffice
+                        .dispatchNumber("2024-0001")
+                        .status(StatusType.ASSIGNED)
+                        .transporter(transporter1)
+                        .assignedAt(LocalDateTime.of(2024, 1, 15, 10, 30, 0))
+                        .createdAt(LocalDateTime.of(2024, 1, 15, 10, 0, 0))
+                        .build(),
+
+                // 사무실 2의 배차 (otherOffice) - 필터링되어야 함
+                Dispatch.builder()
+                        .id(102L)
+                        .officeId(2L)  // otherOffice
+                        .dispatchNumber("2024-0002")
+                        .status(StatusType.OPEN)
+                        .createdAt(LocalDateTime.of(2024, 1, 15, 10, 25, 0))
+                        .build(),
+
+                // 사무실 1의 배차 (testOffice) - 포함되어야 함
+                Dispatch.builder()
+                        .id(103L)
+                        .officeId(1L)  // testOffice
+                        .dispatchNumber("2024-0003")
+                        .status(StatusType.COMPLETED)
+                        .transporter(transporter2)
+                        .completedAt(LocalDateTime.of(2024, 1, 15, 10, 20, 0))
+                        .createdAt(LocalDateTime.of(2024, 1, 15, 9, 50, 0))
+                        .build(),
+
+                // HOLD 상태 배차 (사무실 1) - 필터링되어야 함
+                Dispatch.builder()
+                        .id(104L)
+                        .officeId(1L)  // testOffice
+                        .dispatchNumber("2024-0004")
+                        .status(StatusType.HOLD)
+                        .createdAt(LocalDateTime.of(2024, 1, 15, 10, 15, 0))
+                        .build(),
+
+                // 사무실 1의 배차 (testOffice) - 포함되어야 함
+                Dispatch.builder()
+                        .id(105L)
+                        .officeId(1L)  // testOffice
+                        .dispatchNumber("2024-0005")
+                        .status(StatusType.CANCELED)
+                        .canceledAt(LocalDateTime.of(2024, 1, 15, 10, 10, 0))
+                        .createdAt(LocalDateTime.of(2024, 1, 15, 9, 40, 0))
+                        .build()
+        );
+
+        Page<Dispatch> dispatchPage = new PageImpl<>(allDispatches);
+
+        given(dispatchRepository.findAllWithTransporter(any(Pageable.class)))
+                .willReturn(dispatchPage);
+
+        // when
+        List<DispatchFeedRes> result = officeService.getDispatchFeed(limit, testManager);
+
+        // then
+        // 1. 결과 개수 검증: 사무실 1의 배차만 포함되고 HOLD 상태는 제외
+        // ID: 101(ASSIGNED), 103(COMPLETED), 105(CANCELED) = 3개
+        assertThat(result).hasSize(3);
+
+        // 2. 사무실 1의 배차만 포함되었는지 검증
+        assertThat(result)
+                .extracting(DispatchFeedRes::dispatchId)
+                .containsExactly(101L, 103L, 105L);
+
+        // 3. 사무실 2의 배차(ID: 102)는 제외되었는지 확인
+        assertThat(result)
+                .extracting(DispatchFeedRes::dispatchId)
+                .doesNotContain(102L);
+
+        // 4. HOLD 상태 배차(ID: 104)는 제외되었는지 확인
+        assertThat(result)
+                .extracting(DispatchFeedRes::dispatchId)
+                .doesNotContain(104L);
+
+        // 5. 각 피드의 타입 검증
+        assertThat(result.get(0).type()).isEqualTo("assigned");
+        assertThat(result.get(1).type()).isEqualTo("completed");
+        assertThat(result.get(2).type()).isEqualTo("canceled");
+    }
+
+    @Test
+    @DisplayName("[Service] 배차 피드 조회 - HOLD 상태는 항상 제외")
+    void getDispatchFeed_ExcludeHoldStatus() {
+        // given
+        Integer limit = 20;
+
+        List<Dispatch> allDispatches = List.of(
+                Dispatch.builder()
+                        .id(101L)
+                        .officeId(1L)
+                        .dispatchNumber("2024-0001")
+                        .status(StatusType.HOLD)
+                        .createdAt(LocalDateTime.now())
+                        .build(),
+                Dispatch.builder()
+                        .id(102L)
+                        .officeId(1L)
+                        .dispatchNumber("2024-0002")
+                        .status(StatusType.OPEN)
+                        .createdAt(LocalDateTime.now())
+                        .build()
+        );
+
+        Page<Dispatch> dispatchPage = new PageImpl<>(allDispatches);
+
+        given(dispatchRepository.findAllWithTransporter(any(Pageable.class)))
+                .willReturn(dispatchPage);
+
+        // when
+        List<DispatchFeedRes> result = officeService.getDispatchFeed(limit, testManager);
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).dispatchId()).isEqualTo(102L);
+        assertThat(result.get(0).type()).isEqualTo("open");
+    }
+
+    @Test
+    @DisplayName("[Service] 배차 피드 조회 - 빈 결과 반환")
+    void getDispatchFeed_EmptyResult() {
+        // given
+        Integer limit = 20;
+        Page<Dispatch> emptyPage = new PageImpl<>(List.of());
+
+        given(dispatchRepository.findAllWithTransporter(any(Pageable.class)))
+                .willReturn(emptyPage);
+
+        // when
+        List<DispatchFeedRes> result = officeService.getDispatchFeed(limit, testManager);
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("[Service] 배차 피드 조회 - 다른 사무실 배차는 모두 제외")
+    void getDispatchFeed_FilterOutAllOtherOfficeDispatches() {
+        // given
+        Integer limit = 20;
+
+        // 모든 배차가 다른 사무실의 것
+        List<Dispatch> allDispatches = List.of(
+                Dispatch.builder()
+                        .id(201L)
+                        .officeId(2L)  // otherOffice
+                        .dispatchNumber("2024-0001")
+                        .status(StatusType.OPEN)
+                        .createdAt(LocalDateTime.now())
+                        .build(),
+                Dispatch.builder()
+                        .id(202L)
+                        .officeId(3L)  // another office
+                        .dispatchNumber("2024-0002")
+                        .status(StatusType.ASSIGNED)
+                        .createdAt(LocalDateTime.now())
+                        .build()
+        );
+
+        Page<Dispatch> dispatchPage = new PageImpl<>(allDispatches);
+
+        given(dispatchRepository.findAllWithTransporter(any(Pageable.class)))
+                .willReturn(dispatchPage);
+
+        // when
+        List<DispatchFeedRes> result = officeService.getDispatchFeed(limit, testManager);
+
+        // then
+        // 모든 배차가 다른 사무실의 것이므로 결과는 비어있어야 함
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("[Service] 배차 피드 조회 - 피드 ID 연번 생성 검증")
+    void getDispatchFeed_FeedIdSequence() {
+        // given
+        Integer limit = 20;
+
+        List<Dispatch> allDispatches = List.of(
+                Dispatch.builder()
+                        .id(101L)
+                        .officeId(1L)
+                        .dispatchNumber("2024-0001")
+                        .status(StatusType.OPEN)
+                        .createdAt(LocalDateTime.now())
+                        .build(),
+                Dispatch.builder()
+                        .id(102L)
+                        .officeId(1L)
+                        .dispatchNumber("2024-0002")
+                        .status(StatusType.ASSIGNED)
+                        .createdAt(LocalDateTime.now())
+                        .build(),
+                Dispatch.builder()
+                        .id(103L)
+                        .officeId(1L)
+                        .dispatchNumber("2024-0003")
+                        .status(StatusType.COMPLETED)
+                        .createdAt(LocalDateTime.now())
+                        .build()
+        );
+
+        Page<Dispatch> dispatchPage = new PageImpl<>(allDispatches);
+
+        given(dispatchRepository.findAllWithTransporter(any(Pageable.class)))
+                .willReturn(dispatchPage);
+
+        // when
+        List<DispatchFeedRes> result = officeService.getDispatchFeed(limit, testManager);
+
+        // then
+        assertThat(result).hasSize(3);
+        assertThat(result.get(0).id()).isEqualTo("feed-01");
+        assertThat(result.get(1).id()).isEqualTo("feed-02");
+        assertThat(result.get(2).id()).isEqualTo("feed-03");
+    }
+}


### PR DESCRIPTION
  ## 관련 이슈
- #57 

## 📌 작업 개요
  <!-- 어떤 기능/버그를 작업했는지 간단히 설명해주세요 -->
  - GET `/api/v1/office/dispatch/feed` API에 사무실 인증 및 데이터 격리 기능 추가
  - 로그인한 사무실의 배차만 조회되도록 officeId 기반 필터링 적용
  - 인증 및 필터링 로직에 대한 테스트 코드 작성 (11개 테스트 케이스)

  ### 주요 변경 사항

  #### 1. 인증 추가
  - **Controller**: `@AuthenticationPrincipal PrincipalDetails user` 파라미터 추가

  #### 2. 데이터 필터링
  - **Service**: `getDispatchFeed(Integer limit, Manager manager)` 메서드 수정
  - 현재 로그인한 Manager의 Office ID를 추출하여 배차 필터링
  - 필터링 조건:
    * `dispatch.officeId == manager.office.id` (현재 사무실 배차만)
    * `dispatch.status != HOLD` (자동배차 진행중 제외)

  #### 3. 테스트 코드
  - **OfficeV1ControllerTest** (5개 테스트)
    * 정상 조회 및 응답 구조 검증
    * 인증 없이 접근 시 401 Unauthorized 검증
    * limit 파라미터 처리 (기본값 20, 커스텀 값) 검증
    * 빈 결과 반환 검증

  - **OfficeServiceTest** (6개 테스트)
    * officeId 기반 필터링 검증 (다른 사무실 배차 제외)
    * HOLD 상태 배차 제외 검증 : open (등록) | assigned (배차) | completed (완료) | canceled (취소) 만 반환
    * 피드 ID 연번 생성 검증
    * 다중 사무실 환경에서의 데이터 격리 검증

  ### 파일 변경
  src/main/java/com/mobility/api/domain/office/
  ├── controller/OfficeV1Controller.java         # 인증 파라미터 추가
  └── service/OfficeService.java                 # officeId 필터링 로직 추가

  src/test/java/com/mobility/api/domain/office/
  ├── controller/OfficeV1ControllerTest.java     # NEW (5 tests)
  └── service/OfficeServiceTest.java             # NEW (6 tests)

  ### 보안 개선
  - 다른 사무실의 배차 정보 접근 불가 (데이터 격리)
  - 인증되지 않은 사용자의 API 접근 차단 (prod/docker 환경)

  ## ✨ 기타 참고 사항
  <!-- 리뷰어가 참고해야 할 사항이나, 보완 예정인 내용이 있다면 작성해주세요 -->
  - Office와 Manager 엔티티의 Builder에 `id` 필드가 포함되지 않아, 테스트 코드에서 Reflection을 사용하여 id를 설정했습니다.
  - 현재 `@CurrentUser` 어노테이션은 TransporterV1Controller에서만 사용 중이며, OfficeV1Controller는 `@AuthenticationPrincipal PrincipalDetails` 방식을 사용 합니다.

  ## ✅ 체크리스트
  - [x] PR 템플릿에 맞추어 작성했어요.
  - [x] PR에 적절한 라벨을 선택했어요.
  - [x] 변경 내용에 대한 테스트를 진행했어요. (11개 테스트 케이스 작성)
  - [x] `application.yml` 파일을 수정했다면, Notion에 업로드, github security 수정 및 공유했어요.
  - [x] 로컬 서버에서 정상 동작을 확인했어요. (main, test)
  - [x] 불필요한 코드는 삭제했어요.
